### PR TITLE
Fix regex to match HTTPS as well for getHostname

### DIFF
--- a/poi.go
+++ b/poi.go
@@ -101,9 +101,9 @@ func GetBranches(conn Connection) ([]Branch, error) {
 }
 
 func getHostname(remoteName string) string {
-	r := regexp.MustCompile("(?:@|//)(.+):")
+	r := regexp.MustCompile("(@|//)(.+?)(:|/)")
 	found := r.FindSubmatch([]byte(remoteName))
-	return string(found[1])
+	return string(found[2])
 }
 
 func applyPullRequest(branches []Branch, prs []PullRequest) []Branch {

--- a/poi.go
+++ b/poi.go
@@ -101,9 +101,9 @@ func GetBranches(conn Connection) ([]Branch, error) {
 }
 
 func getHostname(remoteName string) string {
-	r := regexp.MustCompile("(@|//)(.+?)(:|/)")
+	r := regexp.MustCompile("(?:@|//)(.+?)(?::|/)")
 	found := r.FindSubmatch([]byte(remoteName))
-	return string(found[2])
+	return string(found[1])
 }
 
 func applyPullRequest(branches []Branch, prs []PullRequest) []Branch {


### PR DESCRIPTION
Currently, GitHub has two types of URLs: one is SSH, another is HTTPS. The [`getHostname` function](https://github.com/seachicken/gh-poi/blob/2e2eca8e4e6efebc91db0046b026cfa098238ff4/poi.go#L103-L107) seems not to support HTTPS URL; therefore, `gh-poi` panics due to no matches in case of using HTTPS URL.

```
⠋ Fetching pull requests... panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
main.getHostname({0x1400017a000, 0x6f})
        /home/runner/work/gh-poi/gh-poi/poi.go:106 +0xc4
main.GetBranches({0x100dc2d18, 0x100ea22f0})
        /home/runner/work/gh-poi/gh-poi/poi.go:67 +0x5c
main.main()
        /home/runner/work/gh-poi/gh-poi/main.go:38 +0x278
```

This PR brings a new regex that matches also HTTPS. You can check it out on regex101.com.

* Previous implementation: https://regex101.com/r/7pJr9R/1
* This change: https://regex101.com/r/PmJR16/1