### PR TITLE
Support for windows extension installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,4 +18,4 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: cli/gh-extension-precompile@latest
+    - uses: cli/gh-extension-precompile@v1.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,12 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
 
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
 
     steps:
@@ -15,14 +18,4 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
-
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
-      with:
-        args: release --rm-dist
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: cli/gh-extension-precompile@latest


### PR DESCRIPTION
https://github.com/cli/cli/issues/4618
GoReleaser can't build windows binaries as expected, so change GitHub Action to [gh-extension-precompile](https://github.com/cli/gh-extension-precompile)