### PR TITLE
Add error handling for SAML enforcement error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches: [main]
 
-permissions:
-  repository-projects: read
-
 jobs:
 
   build:
@@ -30,7 +27,7 @@ jobs:
 
     - name: Test
       run: |
-        gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
+        echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
         go test ./... -v -race -coverprofile=coverage.out -covermode=atomic
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test ./... -v -race -coverprofile=coverage.out -covermode=atomic
+      run: |
+        gh auth login --with-token ${{secrets.GITHUB_TOKEN}}
+        go test ./... -v -race -coverprofile=coverage.out -covermode=atomic
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  repository-projects: read
+
 jobs:
 
   build:
@@ -27,7 +30,7 @@ jobs:
 
     - name: Test
       run: |
-        gh auth login --with-token ${{secrets.GITHUB_TOKEN}}
+        gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
         go test ./... -v -race -coverprofile=coverage.out -covermode=atomic
 
     - name: Upload coverage to Codecov

--- a/connmock/stub.go
+++ b/connmock/stub.go
@@ -38,6 +38,18 @@ func NewConf(times *Times) *Conf {
 	}
 }
 
+func (s *Stub) CheckRepos(err error, conf *Conf) *Stub {
+	s.t.Helper()
+	configure(
+		s.Conn.
+			EXPECT().
+			CheckRepos(gomock.Any()).
+			Return(err),
+		conf,
+	)
+	return s
+}
+
 func (s *Stub) GetRepoNames(path string, err error, conf *Conf) *Stub {
 	s.t.Helper()
 	configure(

--- a/mocks/poi_mock.go
+++ b/mocks/poi_mock.go
@@ -33,6 +33,20 @@ func (m *MockConnection) EXPECT() *MockConnectionMockRecorder {
 	return m.recorder
 }
 
+// CheckRepos mocks base method.
+func (m *MockConnection) CheckRepos(repoNames []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckRepos", repoNames)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckRepos indicates an expected call of CheckRepos.
+func (mr *MockConnectionMockRecorder) CheckRepos(repoNames interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRepos", reflect.TypeOf((*MockConnection)(nil).CheckRepos), repoNames)
+}
+
 // DeleteBranches mocks base method.
 func (m *MockConnection) DeleteBranches(branchNames []string) (string, error) {
 	m.ctrl.T.Helper()

--- a/poi_test.go
+++ b/poi_test.go
@@ -14,6 +14,7 @@ func Test_ShouldBeDeletableWhenBranchesAssociatedWithMergedPR(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := connmock.Setup(ctrl).
+		CheckRepos(nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBrancheNames("@main_issue1", nil, nil).
 		GetPullRequests("issue1Merged", nil, nil)
@@ -39,6 +40,7 @@ func Test_ShouldBeDeletableWhenBranchesAssociatedWithUpstreamMergedPR(t *testing
 	defer ctrl.Finish()
 
 	s := connmock.Setup(ctrl).
+		CheckRepos(nil, nil).
 		GetRepoNames("origin_upstream", nil, nil).
 		GetBrancheNames("@main_issue1", nil, nil).
 		GetPullRequests("issue1UpMerged", nil, nil)
@@ -64,6 +66,7 @@ func Test_ShouldNotDeletableWhenBranchesAssociatedWithClosedPR(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := connmock.Setup(ctrl).
+		CheckRepos(nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBrancheNames("@main_issue1", nil, nil).
 		GetPullRequests("issue1Closed", nil, nil)
@@ -89,6 +92,7 @@ func Test_ShouldBeDeletableWhenBranchesAssociatedWithMergedAndClosedPRs(t *testi
 	defer ctrl.Finish()
 
 	s := connmock.Setup(ctrl).
+		CheckRepos(nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBrancheNames("@main_issue1", nil, nil).
 		GetPullRequests("issue1Merged_issue1Closed", nil, nil)
@@ -122,11 +126,25 @@ func Test_ReturnsAnErrorWhenGetRepoNamesFails(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func Test_ReturnsAnErrorWhenCheckReposFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s := connmock.Setup(ctrl).
+		CheckRepos(errors.New("failed to run external command: gh"), nil).
+		GetRepoNames("origin", nil, nil)
+
+	_, err := GetBranches(s.Conn)
+
+	assert.NotNil(t, err)
+}
+
 func Test_ReturnsAnErrorWhenGetBrancheNamesFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	s := connmock.Setup(ctrl).
+		CheckRepos(nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBrancheNames("@main_issue1", errors.New("failed to run external command: gh"), nil)
 
@@ -140,6 +158,7 @@ func Test_ReturnsAnErrorWhenGetPullRequestsFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := connmock.Setup(ctrl).
+		CheckRepos(nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBrancheNames("@main_issue1", nil, nil).
 		GetPullRequests("issue1Merged", errors.New("failed to run external command: gh"), nil)


### PR DESCRIPTION
Added error handling because pull requests related to branches are not displayed when SAML is enabled.

Related PR:
https://github.com/cli/cli/pull/4241