### PR TITLE
Support for newlines in Windows

### DIFF
--- a/poi.go
+++ b/poi.go
@@ -643,7 +643,8 @@ func branchNameExists(branchName string, branches []Branch) bool {
 }
 
 func splitLines(text string) []string {
-	return strings.FieldsFunc(text, func(c rune) bool { return c == '\n' })
+	return strings.FieldsFunc(strings.Replace(text, "\r\n", "\n", -1),
+		func(c rune) bool { return c == '\n' })
 }
 
 func (b Branch) IsDetached() bool {


### PR DESCRIPTION
Does not run "gh poi" on Windows.

```
PS C:\Users\seito\git\GitHub\can> gh poi --dry-run
== DRY RUN ==
✕ Fetching pull requests...
/seachicken/can --json owner --json name --json parent --json defaultBranchRef]
parse "https://github.com\r/api/graphql": net/url: invalid control character in URL
```

"\r\n" was not being parsed, so it was fixed.