### PR TITLE
Does not fail even when `git status` returns an error

### DIFF
--- a/poi.go
+++ b/poi.go
@@ -133,12 +133,7 @@ func GetBranches(conn Connection, dryRun bool) ([]Branch, error) {
 	}
 
 	branches = applyPullRequest(branches, prs, conn)
-
-	uncommittedChanges, err := conn.GetUncommittedChanges()
-	if err != nil {
-		return nil, err
-	}
-
+	uncommittedChanges, _ := conn.GetUncommittedChanges()
 	branches = checkDeletion(branches, uncommittedChanges)
 
 	needsCheckout := false

--- a/poi_test.go
+++ b/poi_test.go
@@ -964,7 +964,8 @@ func Test_ReturnsAnErrorWhenGetPullRequestsFails(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func Test_ReturnsAnErrorWhenGetUncommittedChangesFails(t *testing.T) {
+// https://github.com/seachicken/gh-poi/issues/57
+func Test_DoesNotReturnsAnErrorWhenGetUncommittedChangesFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -991,7 +992,7 @@ func Test_ReturnsAnErrorWhenGetUncommittedChangesFails(t *testing.T) {
 
 	_, err := GetBranches(s.Conn, false)
 
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 }
 
 func Test_ReturnsAnErrorWhenCheckoutBranchFails(t *testing.T) {


### PR DESCRIPTION
Fixes #57 