### PR TITLE
Fix fail when branch name and directory name are the same

### DIFF
--- a/conn/command.go
+++ b/conn/command.go
@@ -68,7 +68,7 @@ func (conn *Connection) GetMergedBranchNames() (string, error) {
 
 func (conn *Connection) GetLog(branchName string) (string, error) {
 	args := []string{
-		"log", "--first-parent", "--max-count=30", "--format=%H", branchName,
+		"log", "--first-parent", "--max-count=30", "--format=%H", branchName, "--",
 	}
 	return run("git", args)
 }


### PR DESCRIPTION
Fixed #64 