### PR TITLE
Fix/comma containg branch name

### DIFF
--- a/conn/command.go
+++ b/conn/command.go
@@ -54,7 +54,7 @@ func (conn *Connection) GetRepoNames(hostname string, repoName string) (string, 
 func (conn *Connection) GetBranchNames() (string, error) {
 	args := []string{
 		"branch", "-v", "--no-abbrev",
-		"--format=%(HEAD),%(refname:lstrip=2),%(objectname)",
+		"--format=%(HEAD):%(refname:lstrip=2):%(objectname)",
 	}
 	return run("git", args)
 }

--- a/conn/fixtures/git/branch_@issue1.txt
+++ b/conn/fixtures/git/branch_@issue1.txt
@@ -1,1 +1,1 @@
-*,issue1,a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
+*:issue1:a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0

--- a/conn/fixtures/git/branch_@main.txt
+++ b/conn/fixtures/git/branch_@main.txt
@@ -1,1 +1,1 @@
-*,main,6ebe3d30d23531af56bd23b5a098d3ccae2a534a
+*:main:6ebe3d30d23531af56bd23b5a098d3ccae2a534a

--- a/conn/fixtures/git/branch_@main_forkMain.txt
+++ b/conn/fixtures/git/branch_@main_forkMain.txt
@@ -1,2 +1,2 @@
- ,fork/main,a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
-*,main,6ebe3d30d23531af56bd23b5a098d3ccae2a534a
+ :fork/main:a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
+*:main:6ebe3d30d23531af56bd23b5a098d3ccae2a534a

--- a/conn/fixtures/git/branch_@main_issue1.txt
+++ b/conn/fixtures/git/branch_@main_issue1.txt
@@ -1,2 +1,2 @@
- ,issue1,a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
-*,main,6ebe3d30d23531af56bd23b5a098d3ccae2a534a
+ :issue1:a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
+*:main:6ebe3d30d23531af56bd23b5a098d3ccae2a534a

--- a/conn/fixtures/git/branch_main_@detached.txt
+++ b/conn/fixtures/git/branch_main_@detached.txt
@@ -1,2 +1,2 @@
-*,(HEAD detached at a97e963),a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
- ,main,6ebe3d30d23531af56bd23b5a098d3ccae2a534a
+*:(HEAD detached at a97e963):a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
+ :main:6ebe3d30d23531af56bd23b5a098d3ccae2a534a

--- a/conn/fixtures/git/branch_main_@issue1.txt
+++ b/conn/fixtures/git/branch_main_@issue1.txt
@@ -1,2 +1,2 @@
-*,issue1,a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
- ,main,6ebe3d30d23531af56bd23b5a098d3ccae2a534a
+*:issue1:a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
+ :main:6ebe3d30d23531af56bd23b5a098d3ccae2a534a

--- a/poi.go
+++ b/poi.go
@@ -467,10 +467,9 @@ func toBranch(branchNames []string) []Branch {
 
 	for _, branchName := range branchNames {
 		splitedNames := strings.Split(branchName, ":")
-		head := splitedNames[0] == "*"
 
 		results = append(results, Branch{
-			head,
+			splitedNames[0] == "*",
 			splitedNames[1],
 			false,
 			[]string{},

--- a/poi.go
+++ b/poi.go
@@ -467,13 +467,17 @@ func toBranch(branchNames []string) []Branch {
 
 	for _, branchName := range branchNames {
 		splitedNames := strings.Split(branchName, ",")
+
+		headValue := splitedNames[0]
+		refNameValue := strings.Join(splitedNames[1:len(splitedNames)-1], ",")
+
 		head := false
-		if splitedNames[0] == "*" {
+		if headValue == "*" {
 			head = true
 		}
 		results = append(results, Branch{
 			head,
-			splitedNames[1],
+			refNameValue,
 			false,
 			[]string{},
 			[]PullRequest{},

--- a/poi.go
+++ b/poi.go
@@ -466,10 +466,10 @@ func toBranch(branchNames []string) []Branch {
 	results := []Branch{}
 
 	for _, branchName := range branchNames {
-		splitedNames := strings.Split(branchName, ",")
+		splitedNames := strings.Split(branchName, ":")
 
 		headValue := splitedNames[0]
-		refNameValue := strings.Join(splitedNames[1:len(splitedNames)-1], ",")
+		refNameValue := splitedNames[1]
 
 		head := headValue == "*"
 		results = append(results, Branch{

--- a/poi.go
+++ b/poi.go
@@ -471,10 +471,7 @@ func toBranch(branchNames []string) []Branch {
 		headValue := splitedNames[0]
 		refNameValue := strings.Join(splitedNames[1:len(splitedNames)-1], ",")
 
-		head := false
-		if headValue == "*" {
-			head = true
-		}
+		head := headValue == "*"
 		results = append(results, Branch{
 			head,
 			refNameValue,

--- a/poi.go
+++ b/poi.go
@@ -467,14 +467,11 @@ func toBranch(branchNames []string) []Branch {
 
 	for _, branchName := range branchNames {
 		splitedNames := strings.Split(branchName, ":")
+		head := splitedNames[0] == "*"
 
-		headValue := splitedNames[0]
-		refNameValue := splitedNames[1]
-
-		head := headValue == "*"
 		results = append(results, Branch{
 			head,
-			refNameValue,
+			splitedNames[1],
 			false,
 			[]string{},
 			[]PullRequest{},


### PR DESCRIPTION
close #70
- #70 

In getting branch, here:
https://github.com/seachicken/gh-poi/blob/b9f2295afad1e175d8cb5fffa20d1d17f083f94f/conn/command.go#L54-L60
The data was obtained in comma-separated format, as in the following: `HEAD,refName,objectName`

However, when obtaining the refNames, it was assumed to be "the second element of split by a comma", so the error occured with comma-contained branch name.

Therefore, I have modified it to use the comma-joined string of "excluding the first and last elements" as the refName. ( f373c6e4573423be4ec42bd240937fe96935c248 )


In addition,

```go
head := false
if headValue == "*" {
  head = true
}
```
I found this writing style a bit redundant,
```go
head := headValue == "*"
```
I have made this modification. ( 9965e37c74868a5536c55969a9822bb24c4c87da )

I am beginner of  Go, so apologies if there are any problems.