### PR TITLE
Use path/filepath instead of path

### DIFF
--- a/conn/command_test.go
+++ b/conn/command_test.go
@@ -2,7 +2,7 @@ package conn
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,8 +88,8 @@ func setGitDir(repoName string, t *testing.T) {
 	gitDirOrg := os.Getenv("GIT_DIR")
 	gitWorkTreeOrg := os.Getenv("GIT_WORK_TREE")
 
-	os.Setenv("GIT_DIR", path.Join(fixturePath, repoName, ".git"))
-	os.Setenv("GIT_WORK_TREE", path.Join(fixturePath, repoName))
+	os.Setenv("GIT_DIR", filepath.Join(fixturePath, repoName, ".git"))
+	os.Setenv("GIT_WORK_TREE", filepath.Join(fixturePath, repoName))
 
 	t.Cleanup(func() {
 		os.Setenv("GIT_DIR", gitDirOrg)

--- a/conn/stub.go
+++ b/conn/stub.go
@@ -1,8 +1,8 @@
 package conn
 
 import (
-	"io/ioutil"
-	"path"
+	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/golang/mock/gomock"
@@ -227,7 +227,7 @@ func (s *Stub) readFile(command string, category string, name string) string {
 	if command == "gh" {
 		ext = ".json"
 	}
-	b, err := ioutil.ReadFile(path.Join(filename, "..", fixturePath, command, category+"_"+name+ext))
+	b, err := os.ReadFile(filepath.Join(filename, "..", fixturePath, command, category+"_"+name+ext))
 	if err != nil {
 		s.t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
`path/filepath` should be used instead of `path` when we handle file paths.
Also, I replaced deprecated `io/ioutil` package.