### PR TITLE
Expanding the scope of repository searches

### DIFF
--- a/conn/stub.go
+++ b/conn/stub.go
@@ -209,7 +209,7 @@ func (s *Stub) GetPullRequests(filename string, err error, conf *Conf) *Stub {
 	configure(
 		s.Conn.
 			EXPECT().
-			GetPullRequests(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			GetPullRequests(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(s.readFile("gh", "pr", filename), err),
 		conf,
 	)

--- a/mocks/poi_mock.go
+++ b/mocks/poi_mock.go
@@ -169,18 +169,18 @@ func (mr *MockConnectionMockRecorder) GetMergedBranchNames(ctx, remoteName, bran
 }
 
 // GetPullRequests mocks base method.
-func (m *MockConnection) GetPullRequests(ctx context.Context, hostname string, repoNames []string, queryHashes string) (string, error) {
+func (m *MockConnection) GetPullRequests(ctx context.Context, hostname, orgs, repos, queryHashes string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPullRequests", ctx, hostname, repoNames, queryHashes)
+	ret := m.ctrl.Call(m, "GetPullRequests", ctx, hostname, orgs, repos, queryHashes)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPullRequests indicates an expected call of GetPullRequests.
-func (mr *MockConnectionMockRecorder) GetPullRequests(ctx, hostname, repoNames, queryHashes interface{}) *gomock.Call {
+func (mr *MockConnectionMockRecorder) GetPullRequests(ctx, hostname, orgs, repos, queryHashes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPullRequests", reflect.TypeOf((*MockConnection)(nil).GetPullRequests), ctx, hostname, repoNames, queryHashes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPullRequests", reflect.TypeOf((*MockConnection)(nil).GetPullRequests), ctx, hostname, orgs, repos, queryHashes)
 }
 
 // GetRemoteHeadOid mocks base method.

--- a/poi.go
+++ b/poi.go
@@ -25,7 +25,7 @@ type (
 		GetLsRemoteHeadOid(ctx context.Context, url string, branchName string) (string, error)
 		GetLog(ctx context.Context, branchName string) (string, error)
 		GetAssociatedRefNames(ctx context.Context, oid string) (string, error)
-		GetPullRequests(ctx context.Context, hostname string, repoNames []string, queryHashes string) (string, error)
+		GetPullRequests(ctx context.Context, hostname string, orgs string, repos string, queryHashes string) (string, error)
 		GetUncommittedChanges(ctx context.Context) (string, error)
 		GetConfig(ctx context.Context, key string) (string, error)
 		CheckoutBranch(ctx context.Context, branchName string) (string, error)
@@ -142,8 +142,10 @@ func GetBranches(ctx context.Context, remote Remote, connection Connection, dryR
 	}
 
 	prs := []PullRequest{}
+	orgs := getQueryOrgs(repoNames)
+	repos := getQueryRepos(repoNames)
 	for _, queryHashes := range getQueryHashes(branches) {
-		json, err := connection.GetPullRequests(ctx, remote.Hostname, repoNames, queryHashes)
+		json, err := connection.GetPullRequests(ctx, remote.Hostname, orgs, repos, queryHashes)
 		if err != nil {
 			return nil, err
 		}

--- a/querygen.go
+++ b/querygen.go
@@ -5,6 +5,22 @@ import (
 	"strings"
 )
 
+func getQueryOrgs(repoNames []string) string {
+	var repos strings.Builder
+	for _, name := range repoNames {
+		repos.WriteString(fmt.Sprintf("org:%s ", strings.Split(name, "/")[0]))
+	}
+	return strings.TrimSpace(repos.String())
+}
+
+func getQueryRepos(repoNames []string) string {
+	var repos strings.Builder
+	for _, name := range repoNames {
+		repos.WriteString(fmt.Sprintf("repo:%s ", name))
+	}
+	return strings.TrimSpace(repos.String())
+}
+
 func getQueryHashes(branches []Branch) []string {
 	results := []string{}
 

--- a/querygen_test.go
+++ b/querygen_test.go
@@ -6,7 +6,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_GetQueryHashes(t *testing.T) {
+func Test_GetQueryOrgs(t *testing.T) {
+	assert.Equal(t,
+		"org:parent-owner org:owner",
+		getQueryOrgs([]string{"parent-owner/repo", "owner/repo"}),
+	)
+}
+
+func Test_GetQueryRepos(t *testing.T) {
+	assert.Equal(t,
+		"repo:parent-owner/repo repo:owner/repo",
+		getQueryRepos([]string{"parent-owner/repo", "owner/repo"}),
+	)
+}
+
+func Test_GetQueryHashesWithCommitOid(t *testing.T) {
 	assert.Equal(t,
 		[]string{
 			"hash:356a192b7913b04c54574d18c28d46e6395428ab " +
@@ -65,5 +79,24 @@ func Test_GetQueryHashes(t *testing.T) {
 				},
 				[]PullRequest{}, Unknown,
 			},
-		}))
+		}),
+	)
+}
+
+func Test_GetQueryHashesWithRemoteOid(t *testing.T) {
+	assert.Equal(t,
+		[]string{
+			"hash:356a192b7913b04c54574d18c28d46e6395428ab",
+		},
+		getQueryHashes([]Branch{
+			{true, "issue1", false,
+				"356a192b7913b04c54574d18c28d46e6395428ab",
+				[]string{
+					"da4b9237bacccdf19c0760cab7aec4a8359010b0",
+					"08a2aaaadff191eb76974b9b3d8b71f202c0156e",
+				},
+				[]PullRequest{}, Unknown,
+			},
+		}),
+	)
 }


### PR DESCRIPTION
Added `org:` to the search query because the parent repository of the forked source could not be searched.