### PR TITLE
Remove the deprecated check option

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ func main() {
 	var debug bool
 	flag.BoolVar(&dryRun, "dry-run", false, "Show branches to delete")
 	flag.BoolVar(&debug, "debug", false, "Enable debug logs")
-	flag.BoolVar(&dryRun, "check", false, "[Deprecated] Show branches to delete")
 	flag.Parse()
 	args := flag.Args()
 


### PR DESCRIPTION
It's been a long time since I deprecated it, so I'm deleting it.