### PR TITLE
Add help to commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,19 @@ func main() {
 	flag.BoolVar(&dryRun, "dry-run", false, "Show branches to delete")
 	flag.BoolVar(&debug, "debug", false, "Enable debug logs")
 	flag.BoolVar(&dryRun, "check", false, "[Deprecated] Show branches to delete")
+	flag.Usage = func() {
+		fmt.Fprintf(color.Output, "%s\n\n", white("Delete the merged local branches."))
+		fmt.Fprintf(color.Output, "%s\n", whiteBold("USAGE"))
+		fmt.Fprintf(color.Output, "  %s\n\n", white("gh poi <command> [flags]"))
+		fmt.Fprintf(color.Output, "%s", whiteBold("COMMANDS"))
+		fmt.Fprintf(color.Output, "%s\n", white(`
+  protect:   Protect local branches from deletion
+  unprotect: Unprotect local branches
+  `))
+		fmt.Fprintf(color.Output, "%s\n", whiteBold("FLAGS"))
+		flag.PrintDefaults()
+		fmt.Println()
+	}
 	flag.Parse()
 	args := flag.Args()
 
@@ -40,11 +53,21 @@ func main() {
 		switch subcmd {
 		case "protect":
 			protectCmd := flag.NewFlagSet("protect", flag.ExitOnError)
+			protectCmd.Usage = func() {
+				fmt.Fprintf(color.Output, "%s\n\n", white("Protect local branches from deletion."))
+				fmt.Fprintf(color.Output, "%s\n", whiteBold("USAGE"))
+				fmt.Fprintf(color.Output, "  %s\n\n", white("gh poi protect <branchname>..."))
+			}
 			protectCmd.Parse(args)
 
 			runProtect(args, debug)
 		case "unprotect":
 			unprotectCmd := flag.NewFlagSet("unprotect", flag.ExitOnError)
+			unprotectCmd.Usage = func() {
+				fmt.Fprintf(color.Output, "%s\n\n", white("Unprotect local branches."))
+				fmt.Fprintf(color.Output, "%s\n", whiteBold("USAGE"))
+				fmt.Fprintf(color.Output, "  %s\n\n", white("gh poi unprotect <branchname>..."))
+			}
 			unprotectCmd.Parse(args)
 
 			runUnprotect(args, debug)


### PR DESCRIPTION
Resolves #96 

```
$ gh poi --help
Delete the merged local branches.

USAGE
  gh poi <command> [flags]

COMMANDS
  protect:   Protect local branches from deletion
  unprotect: Unprotect local branches

FLAGS
  -check
        [Deprecated] Show branches to delete
  -debug
        Enable debug logs
  -dry-run
        Show branches to delete


$ gh poi protect --help
Protect local branches from deletion.

USAGE
  gh poi protect <branchname>...


$ gh poi unprotect --help
Unprotect local branches.

USAGE
  gh poi unprotect <branchname>...
```