### PR TITLE
Force disable gh color output

### DIFF
--- a/conn/command.go
+++ b/conn/command.go
@@ -203,7 +203,7 @@ func (conn *Connection) run(ctx context.Context, name string, args []string, mas
 	cmd := exec.CommandContext(ctx, cmdPath, args...)
 	cmd.Stdout = &stdout
 	if name == "gh" {
-		cmd.Env = append(os.Environ(), "NO_COLOR=1")
+		cmd.Env = append(os.Environ(), "CLICOLOR_FORCE=0")
 	}
 
 	start := time.Now()


### PR DESCRIPTION
Can either run poi command with `CLICOLOR_FORCE` environment.
https://github.com/seachicken/gh-poi/issues/104#issuecomment-1591581949
https://github.com/cli/cli/discussions/7584#discussioncomment-6218564