### PR TITLE
Use go-version-file instead of go-version

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
 
     - name: Test
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
Use the version specified in the 'go.mod' file instead of the hardcoded version.

ref: https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file