### PR TITLE
Fix parsing of ssh userinfo

### DIFF
--- a/shared/remote.go
+++ b/shared/remote.go
@@ -13,7 +13,8 @@ type (
 	}
 )
 
-var regex = regexp.MustCompile(`^(?:\w+://|\w+@)?([a-zA-Z0-9\.-]+)[:/](.+?/.+?)(?:\.git|)$`)
+// https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
+var regex = regexp.MustCompile(`^(?:(?:[a-zA-Z0-9-._~]+)(?:://|@))?([a-zA-Z0-9-._~]+)[:/](.+?/.+?)(?:\.git|)$`)
 
 func NewRemote(remoteConfig string) Remote {
 	splitConfig := strings.Fields(remoteConfig)

--- a/shared/remote_test.go
+++ b/shared/remote_test.go
@@ -17,6 +17,17 @@ func Test_CreateRemoteWithScpLikeUrl(t *testing.T) {
 	)
 }
 
+func Test_CreateRemoteWithScpLikeUrlAndCustomUserinfo(t *testing.T) {
+	assert.Equal(t,
+		Remote{
+			Name:     "origin",
+			Hostname: "github.com",
+			RepoName: "org/repo",
+		},
+		NewRemote("origin	git0-._~@github.com:org/repo (fetch)"),
+	)
+}
+
 func Test_CreateRemoteWithScpLikeUrlWithoutUserinfo(t *testing.T) {
 	assert.Equal(t,
 		Remote{


### PR DESCRIPTION
Fix an issue where `git remote -v` did not work if the URL was `origin	hoge-1@github.com:org/repo (fetch)`