### PR TITLE
bump codecov/codecov-action v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,6 @@ jobs:
         go test $(go list ../... | grep -v /conn) -v -race -coverprofile=coverage.out -covermode=atomic
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         directory: ./ci-test/


### PR DESCRIPTION
This pull request fixes the following warning:

> The following actions uses node12 which is deprecated and will be forced to run on node16: codecov/codecov-action@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/