### PR TITLE
Add an option to show version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ builds:
       - freebsd
       - linux
       - windows
+    ldflags:
+      - "-X github.com/seachicken/gh-poi/main.Version={{ .Version }}"
 archives:
   - name_template: "{{ .Os }}-{{ .Arch }}"
     format: binary

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ import (
 	"github.com/seachicken/gh-poi/shared"
 )
 
+var Version = "dev"
+
 var (
 	bold    = color.New(color.Bold).SprintFunc()
 	hiBlack = color.New(color.FgHiBlack).SprintFunc()
@@ -59,9 +61,11 @@ func main() {
 	state := Merged
 	var dryRun bool
 	var debug bool
+	var showVersion bool
 	flag.Var(&state, "state", "Specify the PR state to delete by {closed|merged}")
 	flag.BoolVar(&dryRun, "dry-run", false, "Show branches to delete without actually deleting it")
 	flag.BoolVar(&debug, "debug", false, "Enable debug logs")
+	flag.BoolVar(&showVersion, "version", false, "Show the version")
 	flag.Usage = func() {
 		fmt.Fprintf(color.Output, "%s\n\n", "Delete the merged local branches.")
 		fmt.Fprintf(color.Output, "%s\n", bold("USAGE"))
@@ -76,6 +80,12 @@ func main() {
 		fmt.Println()
 	}
 	flag.Parse()
+
+	if showVersion {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
+
 	args := flag.Args()
 
 	if len(args) == 0 {


### PR DESCRIPTION
Hi. Thank you for creating such a great extension! 👋🏼  

I was somewhat surprised to find that the extension doesn't have an option to display its version, such as a `-version` option. That's why I created this PR. If you'd prefer not to include, please feel free to reject the suggestion.

Thank you. 😃 

---

This adds an option to show the extension version. E.g.

```sh-session
$ go poi -version
v0.13.0
```

To locally test this change, run:

```sh-session
$ go build -ldflags '-X main.Version=v1.0.0' -o tmp-app && ./tmp-app -version && rm -f tmp-app
v1.0.0
```