### PR TITLE
Show help flags in double dashes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -261,7 +261,7 @@ func applyCommits(ctx context.Context, remote shared.Remote, branches []shared.B
 
 	type remoteBranchResult struct {
 		branch shared.Branch
-		err error
+		err    error
 	}
 
 	results := []shared.Branch{}

--- a/main.go
+++ b/main.go
@@ -72,7 +72,15 @@ func main() {
   unprotect: Unprotect local branches
   `)
 		fmt.Fprintf(color.Output, "%s\n", bold("FLAGS"))
-		flag.PrintDefaults()
+		maxLen := 0
+		flag.VisitAll(func(f *flag.Flag) {
+			if len(f.Name) > maxLen {
+				maxLen = len(f.Name)
+			}
+		})
+		flag.VisitAll(func(f *flag.Flag) {
+			fmt.Fprintf(color.Output, "  --%-*s %s\n", maxLen, f.Name, f.Usage)
+		})
 		fmt.Println()
 	}
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 			}
 		})
 		flag.VisitAll(func(f *flag.Flag) {
-			fmt.Fprintf(color.Output, "  --%-*s %s\n", maxLen, f.Name, f.Usage)
+			fmt.Fprintf(color.Output, "  --%-*s %s\n", maxLen+2, f.Name, f.Usage)
 		})
 		fmt.Println()
 	}


### PR DESCRIPTION
Resolves #138 

**As-is**

```sh
seito@seitoPro gh-poi % gh poi --help                                                                                                                                                                          [main]
Delete the merged local branches.

USAGE
  gh poi <command> [flags]

COMMANDS
  protect:   Protect local branches from deletion
  unprotect: Unprotect local branches

FLAGS
  -debug
        Enable debug logs
  -dry-run
        Show branches to delete without actually deleting it
  -state value
        Specify the PR state to delete by {closed|merged} (default merged)
```

**To-be**

```sh
seito@seitoPro gh-poi % gh poi --help
Delete the merged local branches.

USAGE
  gh poi <command> [flags]

COMMANDS
  protect:   Protect local branches from deletion
  unprotect: Unprotect local branches

FLAGS
  --debug     Enable debug logs
  --dry-run   Show branches to delete without actually deleting it
  --state     Specify the PR state to delete by {closed|merged}
```