### PR TITLE
Show an error when protect fails

### DIFF
--- a/cmd/protect/protect.go
+++ b/cmd/protect/protect.go
@@ -3,6 +3,7 @@ package protect
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/seachicken/gh-poi/cmd"
 	"github.com/seachicken/gh-poi/shared"
@@ -22,6 +23,8 @@ func ProtectBranches(ctx context.Context, targetBranchNames []string, connection
 			if err != nil {
 				return err
 			}
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: '%s' is not a valid branch name\n", targetName)
 		}
 	}
 
@@ -38,6 +41,8 @@ func UnprotectBranches(ctx context.Context, targetBranchNames []string, connecti
 	for _, targetName := range targetBranchNames {
 		if cmd.BranchNameExists(targetName, branches) {
 			connection.RemoveConfig(ctx, fmt.Sprintf("branch.%s.gh-poi-protected", targetName))
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: '%s' is not a valid branch name\n", targetName)
 		}
 	}
 


### PR DESCRIPTION
`git worktree lock` like, silent on success, error if a non-existent branch is specified.

```sh
seito@seitoPro gh-poi % gh poi protect aaa main bbb                                                                                                                         [102-show-results-gh-poi-protect-command]
warning: 'aaa' is not a valid branch name
warning: 'bbb' is not a valid branch name
```