### PR TITLE
Do not delete locked worktrees

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -544,6 +544,10 @@ func getDeleteStatus(branch shared.Branch, state shared.PullRequestState) shared
 		return shared.NotDeletable
 	}
 
+	if branch.Worktree != nil && branch.Worktree.IsLocked {
+		return shared.NotDeletable
+	}
+
 	if branch.HasTrackedChanges {
 		return shared.NotDeletable
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -32,7 +32,7 @@ func Test_DeletableWhenRemoteBranchesAssociatedWithMergedPR(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -72,7 +72,7 @@ func Test_DeletableWhenLsRemoteBranchesAssociatedWithMergedPR(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -116,7 +116,7 @@ func Test_DeletableWhenBranchesAssociatedWithMergedPR(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -159,7 +159,7 @@ func Test_DeletableWhenBranchesAssociatedWithSquashAndMergedPR(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -202,7 +202,7 @@ func Test_DeletableWhenBranchesAssociatedWithUpstreamSquashAndMergedPR(t *testin
 		}, nil, nil).
 		GetPullRequests("issue1UpMerged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -245,7 +245,7 @@ func Test_DeletableWhenPRCheckoutBranchesAssociatedWithUpstreamSquashAndMergedPR
 		}, nil, nil).
 		GetPullRequests("forkMainUpMerged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -288,7 +288,7 @@ func Test_DeletableWhenBranchIsCheckedOutWithCheckIsFalse(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -332,7 +332,7 @@ func Test_DeletableWhenBranchIsCheckedOutWithCheckIsTrue(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -376,7 +376,7 @@ func Test_DeletableWhenBranchIsCheckedOutWithoutDefaultBranch(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.issue1.merge", Filename: "mergeIssue1"},
 			{BranchName: "branch.issue1.remote", Filename: "remote"},
@@ -417,7 +417,7 @@ func Test_NotDeletableWhenBranchHasModifiedUncommittedChanges(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges(" M README.md", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -461,7 +461,7 @@ func Test_DeletableWhenBranchHasUntrackedUncommittedChanges(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("?? new.txt", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -505,7 +505,7 @@ func Test_NotDeletableWhenPRIsClosedAndStateOptionIsMerged(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Closed", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -548,7 +548,7 @@ func Test_DeletableWhenPRIsClosedAndStateOptionIsClosed(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Closed", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -591,7 +591,7 @@ func Test_DeletableWhenPRHasMergedAndClosedAndStateOptionIsMerged(t *testing.T) 
 		}, nil, nil).
 		GetPullRequests("issue1Merged_issue1Closed", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -634,7 +634,7 @@ func Test_DeletableWhenPRHasMergedAndClosedAndStateOptionIsClosed(t *testing.T) 
 		}, nil, nil).
 		GetPullRequests("issue1Merged_issue1Closed", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -679,7 +679,7 @@ func Test_NotDeletableWhenBranchesAssociatedWithNotFullyMergedPR(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -722,7 +722,7 @@ func Test_NotDeletableWhenDefaultBranchAssociatedWithMergedPR(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("mainMerged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -762,7 +762,7 @@ func Test_NotDeletableWhenBranchIsLocked(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -804,7 +804,7 @@ func Test_NotDeletableWhenBranchIsLockedForCompatibility(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -850,7 +850,7 @@ func Test_BranchesAndPRsAreNotAssociatedWhenManyLocalCommitsAreAhead(t *testing.
 		}, nil, nil).
 		GetPullRequests("notFound", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -893,7 +893,7 @@ func Test_NoCommitHistoryWhenFirstCommitOfTopicBranchIsAssociatedWithDefaultBran
 		}, nil, nil).
 		GetPullRequests("notFound", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -936,7 +936,7 @@ func Test_NoCommitHistoryWhenDetachedBranch(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("notFound", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -990,7 +990,7 @@ func Test_DoesNotReturnsErrorWhenGetSshConfigFails(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -1159,7 +1159,7 @@ func Test_ReturnsErrorWhenGetPullRequestsFails(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", ErrCommand, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
 			{BranchName: "branch.main.gh-poi-protected", Filename: "empty"},
@@ -1234,7 +1234,7 @@ func Test_ReturnsErrorWhenCheckoutBranchFails(t *testing.T) {
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees("", nil, nil).
+		GetWorktrees("none", nil, nil).
 		CheckoutBranch(ErrCommand, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
@@ -1299,53 +1299,76 @@ func Test_DeletableWithWorktree(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	worktreeOutput := `worktree /path/to/main
-HEAD abc123
-branch refs/heads/main
-
-worktree /path/to/issue1-wt
-HEAD def456
-branch refs/heads/issue1
-`
-
 	s := conn.Setup(ctrl).
 		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
-		GetBranchNames("@main_issue1", nil, nil).
-		GetMergedBranchNames("@main_issue1", nil, nil).
+		GetBranchNames("@main_linkedIssue1", nil, nil).
+		GetMergedBranchNames("@main_linkedIssue1", nil, nil).
 		GetRemoteHeadOid([]conn.RemoteHeadStub{
-			{BranchName: "issue1", Filename: "issue1"},
+			{BranchName: "linkedIssue1", Filename: "issue1"},
 		}, nil, nil).
 		GetLog([]conn.LogStub{
-			{BranchName: "main", Filename: "main_issue1Merged"}, {BranchName: "issue1", Filename: "issue1Merged"},
+			{BranchName: "main", Filename: "main_issue1Merged"}, {BranchName: "linkedIssue1", Filename: "issue1Merged"},
 		}, nil, nil).
-		GetPullRequests("issue1Merged", nil, nil).
+		GetPullRequests("linkedIssue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
-		GetWorktrees(worktreeOutput, nil, nil).
+		GetWorktrees("linked", nil, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.merge", Filename: "mergeMain"},
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
 			{BranchName: "branch.main.gh-poi-protected", Filename: "empty"},
-			{BranchName: "branch.issue1.merge", Filename: "mergeIssue1"},
-			{BranchName: "branch.issue1.gh-poi-locked", Filename: "empty"},
-			{BranchName: "branch.issue1.gh-poi-protected", Filename: "empty"},
+			{BranchName: "branch.linkedIssue1.merge", Filename: "mergeIssue1"},
+			{BranchName: "branch.linkedIssue1.gh-poi-locked", Filename: "empty"},
+			{BranchName: "branch.linkedIssue1.gh-poi-protected", Filename: "empty"},
 		}, nil, nil)
 	remote, _ := GetRemote(context.Background(), s.Conn)
 
 	actual, _ := GetBranches(context.Background(), remote, s.Conn, shared.Merged, false)
 
 	assert.Equal(t, 2, len(actual))
-	assert.Equal(t, "issue1", actual[0].Name)
+	assert.Equal(t, "linkedIssue1", actual[0].Name)
 	assert.Equal(t, shared.Deletable, actual[0].State)
-	assert.NotNil(t, actual[0].Worktree)
-	assert.Equal(t, "/path/to/issue1-wt", actual[0].Worktree.Path)
-	assert.Equal(t, "issue1", actual[0].Worktree.Branch)
-	assert.Equal(t, false, actual[0].Worktree.IsMain)
 	assert.Equal(t, "main", actual[1].Name)
 	assert.Equal(t, shared.NotDeletable, actual[1].State)
-	assert.NotNil(t, actual[1].Worktree)
-	assert.Equal(t, "/path/to/main", actual[1].Worktree.Path)
-	assert.Equal(t, true, actual[1].Worktree.IsMain)
+}
+
+func Test_NotDeletableWithLockedWorktree(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s := conn.Setup(ctrl).
+		CheckRepos(nil, nil).
+		GetRemoteNames("origin", nil, nil).
+		GetSshConfig("github.com", nil, nil).
+		GetRepoNames("origin", nil, nil).
+		GetBranchNames("@main_linkedIssue1", nil, nil).
+		GetMergedBranchNames("@main_linkedIssue1", nil, nil).
+		GetRemoteHeadOid([]conn.RemoteHeadStub{
+			{BranchName: "linkedIssue1", Filename: "issue1"},
+		}, nil, nil).
+		GetLog([]conn.LogStub{
+			{BranchName: "main", Filename: "main_issue1Merged"}, {BranchName: "linkedIssue1", Filename: "issue1Merged"},
+		}, nil, nil).
+		GetPullRequests("linkedIssue1Merged", nil, nil).
+		GetUncommittedChanges("", nil, nil).
+		GetWorktrees("locked", nil, nil).
+		GetConfig([]conn.ConfigStub{
+			{BranchName: "branch.main.merge", Filename: "mergeMain"},
+			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
+			{BranchName: "branch.main.gh-poi-protected", Filename: "empty"},
+			{BranchName: "branch.linkedIssue1.merge", Filename: "mergeIssue1"},
+			{BranchName: "branch.linkedIssue1.gh-poi-locked", Filename: "empty"},
+			{BranchName: "branch.linkedIssue1.gh-poi-protected", Filename: "empty"},
+		}, nil, nil)
+	remote, _ := GetRemote(context.Background(), s.Conn)
+
+	actual, _ := GetBranches(context.Background(), remote, s.Conn, shared.Merged, false)
+
+	assert.Equal(t, 2, len(actual))
+	assert.Equal(t, "linkedIssue1", actual[0].Name)
+	assert.Equal(t, shared.NotDeletable, actual[0].State)
+	assert.Equal(t, "main", actual[1].Name)
+	assert.Equal(t, shared.NotDeletable, actual[1].State)
 }

--- a/conn/fixtures/gh/pr_linkedIssue1Merged.json
+++ b/conn/fixtures/gh/pr_linkedIssue1Merged.json
@@ -1,0 +1,30 @@
+{
+  "data": {
+    "search": {
+      "issueCount": 1,
+      "edges": [
+        {
+          "node": {
+            "number": 1,
+            "url": "https://github.com/owner/repo/pull/1",
+            "state": "MERGED",
+            "isDraft": false,
+            "headRefName": "linkedIssue1",
+            "commits": {
+              "nodes": [
+                {
+                  "commit": {
+                    "oid": "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0"
+                  }
+                }
+              ]
+            },
+            "author": {
+              "login": "owner"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/conn/fixtures/git/branchMerged_@main_linkedIssue1.txt
+++ b/conn/fixtures/git/branchMerged_@main_linkedIssue1.txt
@@ -1,0 +1,2 @@
+  linkedIssue1
+* main

--- a/conn/fixtures/git/branch_@main_linkedIssue1.txt
+++ b/conn/fixtures/git/branch_@main_linkedIssue1.txt
@@ -1,0 +1,2 @@
+ :linkedIssue1:a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
+*:main:6ebe3d30d23531af56bd23b5a098d3ccae2a534a

--- a/conn/fixtures/git/worktree_locked.txt
+++ b/conn/fixtures/git/worktree_locked.txt
@@ -1,0 +1,9 @@
+worktree /home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_main
+HEAD 24f9a9b5ea0f4ade510aec4caa34fa713c4b62e6
+branch refs/heads/main
+
+worktree /home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_linkedIssue1
+HEAD 24f9a9b5ea0f4ade510aec4caa34fa713c4b62e6
+branch refs/heads/linkedIssue1
+locked
+

--- a/conn/stub.go
+++ b/conn/stub.go
@@ -43,6 +43,10 @@ type (
 		Filename   string
 	}
 
+	WorktreeStub struct {
+		Filename string
+	}
+
 	ConfigStub struct {
 		BranchName string
 		Filename   string
@@ -266,13 +270,13 @@ func (s *Stub) DeleteBranches(err error, conf *Conf) *Stub {
 	return s
 }
 
-func (s *Stub) GetWorktrees(output string, err error, conf *Conf) *Stub {
+func (s *Stub) GetWorktrees(filename string, err error, conf *Conf) *Stub {
 	s.T.Helper()
 	configure(
 		s.Conn.
 			EXPECT().
 			GetWorktrees(gomock.Any()).
-			Return(output, err),
+			Return(s.ReadFile("git", "worktree", filename), err),
 		conf,
 	)
 	return s

--- a/main.go
+++ b/main.go
@@ -265,6 +265,9 @@ func printBranches(branches []shared.Branch) {
 		if branch.IsLocked {
 			reason = "locked"
 		}
+		if branch.Worktree != nil && branch.Worktree.IsLocked {
+			reason = "worktree locked"
+		}
 		if !branch.IsDefault && len(branch.PullRequests) > 0 && branch.HasTrackedChanges {
 			reason = "uncommitted changes"
 		}

--- a/shared/worktree.go
+++ b/shared/worktree.go
@@ -3,9 +3,10 @@ package shared
 import "strings"
 
 type Worktree struct {
-	Path   string
-	Branch string
-	IsMain bool
+	Path     string
+	Branch   string
+	IsMain   bool
+	IsLocked bool
 }
 
 // ParseWorktrees parses the output of `git worktree list --porcelain`
@@ -23,14 +24,17 @@ func ParseWorktrees(output string) []Worktree {
 				worktrees = append(worktrees, *current)
 			}
 			current = &Worktree{
-				Path:   after,
-				IsMain: isFirst,
+				Path:     after,
+				IsMain:   isFirst,
+				IsLocked: false,
 			}
 			isFirst = false
 		} else if after, ok := strings.CutPrefix(line, "branch refs/heads/"); ok {
 			if current != nil {
 				current.Branch = after
 			}
+		} else if line == "locked" {
+			current.IsLocked = true
 		}
 	}
 

--- a/shared/worktree_test.go
+++ b/shared/worktree_test.go
@@ -11,8 +11,8 @@ func Test_ParseWorktreesWithLinkedWorktree(t *testing.T) {
 	stub := (&conn.Stub{Conn: nil, T: t}).ReadFile("git", "worktree", "linked")
 	assert.Equal(t,
 		[]Worktree{
-			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_main", Branch: "main", IsMain: true},
-			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_linkedIssue1", Branch: "linkedIssue1", IsMain: false},
+			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_main", Branch: "main", IsMain: true, IsLocked: false},
+			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_linkedIssue1", Branch: "linkedIssue1", IsMain: false, IsLocked: false},
 		},
 		ParseWorktrees(stub),
 	)
@@ -22,7 +22,7 @@ func Test_ParseWorktreesWithoutLinkedWorktree(t *testing.T) {
 	stub := (&conn.Stub{Conn: nil, T: t}).ReadFile("git", "worktree", "none")
 	assert.Equal(t,
 		[]Worktree{
-			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_basic", Branch: "main", IsMain: true},
+			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_basic", Branch: "main", IsMain: true, IsLocked: false},
 		},
 		ParseWorktrees(stub),
 	)
@@ -32,8 +32,19 @@ func Test_ParseWorktreesWithDetached(t *testing.T) {
 	stub := (&conn.Stub{Conn: nil, T: t}).ReadFile("git", "worktree", "detached")
 	assert.Equal(t,
 		[]Worktree{
-			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_main", Branch: "main", IsMain: true},
-			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_linkedIssue1", Branch: "", IsMain: false},
+			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_main", Branch: "main", IsMain: true, IsLocked: false},
+			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_linkedIssue1", Branch: "", IsMain: false, IsLocked: false},
+		},
+		ParseWorktrees(stub),
+	)
+}
+
+func Test_ParseWorktreesWithLocked(t *testing.T) {
+	stub := (&conn.Stub{Conn: nil, T: t}).ReadFile("git", "worktree", "locked")
+	assert.Equal(t,
+		[]Worktree{
+			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_main", Branch: "main", IsMain: true, IsLocked: false},
+			{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_linkedIssue1", Branch: "linkedIssue1", IsMain: false, IsLocked: true},
 		},
 		ParseWorktrees(stub),
 	)


### PR DESCRIPTION
A locked worktree is marked as non-deletable because deleting a branch will result in an error.

Output:
```sh
$ gh poi
...
Branches not deleted
* issue1 (worktree: /Users/seito/repo/branch) [worktree locked]
    └─ #1  https://github.com/seachicken/repo/pull/1 seachicken
```