### PR TITLE
Make it deletable on a linked worktree

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -544,8 +544,10 @@ func getDeleteStatus(branch shared.Branch, state shared.PullRequestState) shared
 		return shared.NotDeletable
 	}
 
-	if branch.Worktree != nil && branch.Worktree.IsLocked {
-		return shared.NotDeletable
+	if branch.Worktree != nil {
+		if branch.Worktree.IsLocked || branch.Head {
+			return shared.NotDeletable
+		}
 	}
 
 	if branch.HasTrackedChanges {

--- a/conn/fixtures/git/branchMerged_@main_linkedIssue1.txt
+++ b/conn/fixtures/git/branchMerged_@main_linkedIssue1.txt
@@ -1,2 +1,2 @@
-  linkedIssue1
++ linkedIssue1
 * main

--- a/conn/fixtures/git/branchMerged_main_@linkedIssue1.txt
+++ b/conn/fixtures/git/branchMerged_main_@linkedIssue1.txt
@@ -1,0 +1,2 @@
+* linkedIssue1
++ main

--- a/conn/fixtures/git/branch_main_@linkedIssue1.txt
+++ b/conn/fixtures/git/branch_main_@linkedIssue1.txt
@@ -1,0 +1,2 @@
+*:linkedIssue1:a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0
+ :main:6ebe3d30d23531af56bd23b5a098d3ccae2a534a

--- a/main.go
+++ b/main.go
@@ -256,11 +256,11 @@ func printBranches(branches []shared.Branch) {
 		reason := ""
 		if branch.IsLocked {
 			reason = "locked"
-		}
-		if branch.Worktree != nil && branch.Worktree.IsLocked {
+		} else if branch.Worktree != nil && branch.Worktree.IsLocked {
 			reason = "worktree locked"
-		}
-		if !branch.IsDefault && len(branch.PullRequests) > 0 && branch.HasTrackedChanges {
+		} else if branch.Worktree != nil && !branch.Worktree.IsMain && branch.Head {
+			reason = "worktree linked"
+		} else if !branch.IsDefault && len(branch.PullRequests) > 0 && branch.HasTrackedChanges {
 			reason = "uncommitted changes"
 		}
 		if reason == "" {


### PR DESCRIPTION
According to Git specifications, the linked worktree directory must be deleted before the branch. However, when poi is executed in the linked worktree directory, the directory disappears, making it impossible to delete the branch.
Therefore, if the current directory is a linked worktree, it is excluded from deletion targets.