### PR TITLE
Simplify branch commit collection 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,26 +49,21 @@ func GetRemote(ctx context.Context, connection shared.Connection) (shared.Remote
 			remote.Hostname = ghHost
 		}
 		return remote, nil
-	} else {
-		return shared.Remote{}, err
 	}
+
+	return shared.Remote{}, err
 }
 
 func GetBranches(ctx context.Context, remote shared.Remote, connection shared.Connection, state shared.PullRequestState, dryRun bool) ([]shared.
-	Branch, error) {
+Branch, error) {
 	var repoNames []string
 	var defaultBranchName string
-	if json, err := connection.GetRepoNames(ctx, remote.Hostname, remote.RepoName); err == nil {
-		repoNames, defaultBranchName, err = getRepo(json)
+	if repos, err := connection.GetRepoNames(ctx, remote.Hostname, remote.RepoName); err == nil {
+		repoNames, defaultBranchName, err = getRepo(repos)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		return nil, err
-	}
-
-	err := connection.CheckRepos(ctx, remote.Hostname, repoNames)
-	if err != nil {
 		return nil, err
 	}
 
@@ -137,13 +132,13 @@ func loadBranches(ctx context.Context, remote shared.Remote, defaultBranchName s
 		wg.Add(1)
 		go func(hash string) {
 			defer wg.Done()
-			json, err := connection.GetPullRequests(ctx, remote.Hostname, orgs, repos, hash)
+			pullRequests, err := connection.GetPullRequests(ctx, remote.Hostname, orgs, repos, hash)
 			if err != nil {
 				prChan <- pullRequestResult{err: err}
 				return
 			}
 
-			pr, err := toPullRequests(json)
+			pr, err := toPullRequests(pullRequests)
 			if err != nil {
 				prChan <- pullRequestResult{err: err}
 				return
@@ -282,20 +277,14 @@ func applyCommits(ctx context.Context, remote shared.Remote, branches []shared.B
 				return
 			}
 
+			// Try the selected remote first, then fall back to the
+			// branch's upstream tracking ref. The upstream ref captures
+			// the commit that was actually pushed (and PR'd), even when
+			// the branch tracks a different remote than the one selected.
 			if remoteHeadOid, err := connection.GetRemoteHeadOid(ctx, remote.Name, branch.Name); err == nil {
 				branch.RemoteHeadOid = SplitLines(remoteHeadOid)[0]
-			} else {
-				result, _ := connection.GetConfig(ctx, fmt.Sprintf("branch.%s.remote", branch.Name))
-				splitResults := SplitLines(result)
-				if len(splitResults) > 0 {
-					remoteUrl := splitResults[0]
-					if result, err := connection.GetLsRemoteHeadOid(ctx, remoteUrl, branch.Name); err == nil {
-						splitResults := strings.Fields(result)
-						if len(splitResults) > 0 {
-							branch.RemoteHeadOid = splitResults[0]
-						}
-					}
-				}
+			} else if upstreamOid, err := connection.GetUpstreamOid(ctx, branch.Name); err == nil {
+				branch.RemoteHeadOid = SplitLines(upstreamOid)[0]
 			}
 
 			oids, err := connection.GetLog(ctx, branch.Name)
@@ -304,15 +293,11 @@ func applyCommits(ctx context.Context, remote shared.Remote, branches []shared.B
 				return
 			}
 
-			trimmedOids, err := trimBranch(
-				ctx, SplitLines(oids), branch.RemoteHeadOid, branch.IsMerged,
-				branch.Name, defaultBranchName, connection)
-			if err != nil {
-				resultChan <- remoteBranchResult{err: err}
-				return
+			if logOids := SplitLines(oids); len(logOids) > 0 {
+				branch.Commits = []string{logOids[0]}
+			} else {
+				branch.Commits = []string{}
 			}
-
-			branch.Commits = trimmedOids
 			resultChan <- remoteBranchResult{branch: branch}
 		}(branch)
 	}
@@ -383,55 +368,6 @@ func applyWorktrees(ctx context.Context, branches []shared.Branch, connection sh
 	}
 
 	return results, nil
-}
-
-func trimBranch(ctx context.Context, oids []string, remoteHeadOid string, isMerged bool,
-	branchName string, defaultBranchName string, connection shared.Connection) ([]string, error) {
-	results := []string{}
-	childNames := []string{}
-
-	for i, oid := range oids {
-		if len(remoteHeadOid) > 0 || isMerged {
-			results = append(results, oid)
-			break
-		}
-
-		refNames, err := connection.GetAssociatedRefNames(ctx, oid)
-		if err != nil {
-			return nil, err
-		}
-		names := extractBranchNames(SplitLines(refNames))
-
-		if i == 0 {
-			for _, name := range names {
-				if name == defaultBranchName {
-					return []string{}, nil
-				}
-				if name != branchName {
-					childNames = append(childNames, name)
-				}
-			}
-		}
-
-		for _, name := range names {
-			if name != branchName && !slices.Contains(childNames, name) {
-				return results, nil
-			}
-		}
-
-		results = append(results, oid)
-	}
-
-	return results, nil
-}
-
-func extractBranchNames(refNames []string) []string {
-	result := []string{}
-	r := regexp.MustCompile(`^refs/(?:heads|remotes/.+?)/`)
-	for _, name := range refNames {
-		result = append(result, r.ReplaceAllString(name, ""))
-	}
-	return result
 }
 
 func applyPullRequest(ctx context.Context, branches []shared.Branch, prs []shared.PullRequest, connection shared.Connection) []shared.Branch {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -18,7 +18,6 @@ func Test_BranchIsDeletableWhenRemoteBranchesAssociatedWithMergedPR(t *testing.T
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
@@ -52,19 +51,18 @@ func Test_BranchIsDeletableWhenRemoteBranchesAssociatedWithMergedPR(t *testing.T
 	assert.Equal(t, shared.NotDeletable, actual[1].State)
 }
 
-func Test_BranchIsDeletableWhenLsRemoteBranchesAssociatedWithMergedPR(t *testing.T) {
+func Test_BranchIsDeletableWhenUpstreamTrackingRefMatchesMergedPR(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main_issue1", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid([]conn.LsRemoteHeadStub{
+		GetUpstreamOid([]conn.UpstreamOidStub{
 			{BranchName: "issue1", Filename: "issue1"},
 		}, nil, nil).
 		GetLog([]conn.LogStub{
@@ -78,7 +76,43 @@ func Test_BranchIsDeletableWhenLsRemoteBranchesAssociatedWithMergedPR(t *testing
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
 			{BranchName: "branch.main.gh-poi-protected", Filename: "empty"},
 			{BranchName: "branch.issue1.merge", Filename: "mergeIssue1"},
-			{BranchName: "branch.issue1.remote", Filename: "remote"},
+			{BranchName: "branch.issue1.gh-poi-locked", Filename: "empty"},
+			{BranchName: "branch.issue1.gh-poi-protected", Filename: "empty"},
+		}, nil, nil)
+	remote, _ := GetRemote(context.Background(), s.Conn)
+
+	actual, _ := GetBranches(context.Background(), remote, s.Conn, shared.Merged, false)
+
+	assert.Equal(t, 2, len(actual))
+	assert.Equal(t, "issue1", actual[0].Name)
+	assert.Equal(t, shared.Deletable, actual[0].State)
+	assert.Equal(t, "main", actual[1].Name)
+	assert.Equal(t, shared.NotDeletable, actual[1].State)
+}
+
+func Test_BranchIsDeletableWhenBranchNotOnRemoteButAssociatedWithMergedPR(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s := conn.Setup(ctrl).
+		GetRemoteNames("origin", nil, nil).
+		GetSshConfig("github.com", nil, nil).
+		GetRepoNames("origin", nil, nil).
+		GetBranchNames("@main_issue1", nil, nil).
+		GetMergedBranchNames("@main_issue1", nil, nil).
+		GetRemoteHeadOid(nil, ErrCommand, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
+		GetLog([]conn.LogStub{
+			{BranchName: "main", Filename: "main_issue1Merged"}, {BranchName: "issue1", Filename: "issue1Merged"},
+		}, nil, nil).
+		GetPullRequests("issue1Merged", nil, nil).
+		GetUncommittedChanges("", nil, nil).
+		GetWorktrees("none", nil, nil).
+		GetConfig([]conn.ConfigStub{
+			{BranchName: "branch.main.merge", Filename: "mergeMain"},
+			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
+			{BranchName: "branch.main.gh-poi-protected", Filename: "empty"},
+			{BranchName: "branch.issue1.merge", Filename: "mergeIssue1"},
 			{BranchName: "branch.issue1.gh-poi-locked", Filename: "empty"},
 			{BranchName: "branch.issue1.gh-poi-protected", Filename: "empty"},
 		}, nil, nil)
@@ -98,21 +132,15 @@ func Test_BranchIsDeletableWhenBranchesAssociatedWithMergedPR(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main_issue1", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main_issue1Merged"}, {BranchName: "issue1", Filename: "issue1Merged"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "b8a2645298053fb62ea03e27feea6c483d3fd27e", Filename: "main_issue1"},
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "main_issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -142,20 +170,15 @@ func Test_BranchIsDeletableWhenBranchesAssociatedWithSquashAndMergedPR(t *testin
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -185,20 +208,15 @@ func Test_BranchIsDeletableWhenBranchesAssociatedWithUpstreamSquashAndMergedPR(t
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin_upstream", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1UpMerged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -228,20 +246,15 @@ func Test_BranchIsDeletableWhenPRCheckoutBranchesAssociatedWithUpstreamSquashAnd
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin_upstream", nil, nil).
 		GetBranchNames("@main_forkMain", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "fork/main", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "forkMain"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_forkMain"},
 		}, nil, nil).
 		GetPullRequests("forkMainUpMerged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -271,20 +284,15 @@ func Test_BranchIsDeletableWhenBranchIsCheckedOutWithCheckIsFalse(t *testing.T) 
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("main_@issue1", nil, nil).
 		GetMergedBranchNames("main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -315,20 +323,15 @@ func Test_BranchIsDeletableWhenBranchIsCheckedOutWithCheckIsTrue(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("main_@issue1", nil, nil).
 		GetMergedBranchNames("main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -359,20 +362,15 @@ func Test_BranchIsDeletableWhenBranchIsCheckedOutWithoutDefaultBranch(t *testing
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@issue1", nil, nil).
 		GetMergedBranchNames("empty", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "issue1_originMain"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -400,20 +398,15 @@ func Test_BranchIsNotDeletableWhenBranchHasModifiedUncommittedChanges(t *testing
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("main_@issue1", nil, nil).
 		GetMergedBranchNames("main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges(" M README.md", nil, nil).
@@ -444,20 +437,15 @@ func Test_BranchIsDeletableWhenBranchHasUntrackedUncommittedChanges(t *testing.T
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("main_@issue1", nil, nil).
 		GetMergedBranchNames("main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("?? new.txt", nil, nil).
@@ -488,20 +476,15 @@ func Test_BranchIsNotDeletableWhenPRIsClosedAndStateOptionIsMerged(t *testing.T)
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Closed", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -531,20 +514,15 @@ func Test_BranchIsDeletableWhenPRIsClosedAndStateOptionIsClosed(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Closed", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -574,20 +552,15 @@ func Test_BranchIsDeletableWhenPRHasMergedAndClosedAndStateOptionIsMerged(t *tes
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged_issue1Closed", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -617,20 +590,15 @@ func Test_BranchIsDeletableWhenPRHasMergedAndClosedAndStateOptionIsClosed(t *tes
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged_issue1Closed", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -660,22 +628,15 @@ func Test_BranchIsNotDeletableWhenBranchesAssociatedWithNotFullyMergedPR(t *test
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main_issue1SquashAndMerged"}, {BranchName: "issue1", Filename: "issue1CommitAfterMerge"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "cb197ba87e4ad323b1008c611212deb7da2a4a49", Filename: "main"},
-			{Oid: "b8a2645298053fb62ea03e27feea6c483d3fd27e", Filename: "issue1"},
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -705,20 +666,15 @@ func Test_BranchIsNotDeletableWhenDefaultBranchAssociatedWithMergedPR(t *testing
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("mainMerged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -748,7 +704,6 @@ func Test_BranchIsNotDeletableWhenBranchIsLocked(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
@@ -790,7 +745,6 @@ func Test_BranchIsNotDeletableWhenBranchIsLockedForCompatibility(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
@@ -831,7 +785,6 @@ func Test_BranchIsDeletableWithBaseWorktreeCheckedOut(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
@@ -871,7 +824,6 @@ func Test_BranchIsNotDeletableWithLinkedWorktreeCheckedOut(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
@@ -910,7 +862,6 @@ func Test_BranchIsNotDeletableWithLockedWorktree(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
@@ -949,22 +900,16 @@ func Test_BranchesAndPRsAreNotAssociatedWhenManyLocalCommitsAreAhead(t *testing.
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"},
 			{BranchName: "issue1", Filename: "issue1ManyCommits"}, // return with '--max-count=3'
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "62d5d8280031f607f1db058da959a97f6a8e6d90", Filename: "issue1"},
-			{Oid: "b8a2645298053fb62ea03e27feea6c483d3fd27e", Filename: "issue1"},
-			{Oid: "d787669ee4a103fe0b361fe31c10ea037c72f27c", Filename: "issue1"},
 		}, nil, nil).
 		GetPullRequests("notFound", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -990,24 +935,22 @@ func Test_BranchesAndPRsAreNotAssociatedWhenManyLocalCommitsAreAhead(t *testing.
 	assert.Equal(t, shared.NotDeletable, actual[1].State)
 }
 
-func Test_NoCommitHistoryWhenFirstCommitOfTopicBranchIsAssociatedWithDefaultBranch(t *testing.T) {
+// issue1's head commit is the same as main's, so no distinct PR is found and
+// the branch stays NotDeletable.
+func Test_BranchIsNotDeletableWhenFirstCommitOfTopicBranchIsAssociatedWithDefaultBranch(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "main"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("notFound", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -1027,7 +970,6 @@ func Test_NoCommitHistoryWhenFirstCommitOfTopicBranchIsAssociatedWithDefaultBran
 
 	assert.Equal(t, 2, len(actual))
 	assert.Equal(t, "issue1", actual[0].Name)
-	assert.Equal(t, []string{}, actual[0].Commits)
 	assert.Equal(t, shared.NotDeletable, actual[0].State)
 	assert.Equal(t, "main", actual[1].Name)
 	assert.Equal(t, shared.NotDeletable, actual[1].State)
@@ -1038,19 +980,15 @@ func Test_NoCommitHistoryWhenDetachedBranch(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("main_@detached", nil, nil).
 		GetMergedBranchNames("main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("notFound", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -1091,20 +1029,15 @@ func Test_DoesNotReturnsErrorWhenGetSshConfigFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", ErrCommand, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -1140,28 +1073,11 @@ func Test_ReturnsErrorWhenGetRepoNamesFails(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func Test_ReturnsErrorWhenCheckReposFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	s := conn.Setup(ctrl).
-		CheckRepos(ErrCommand, nil).
-		GetRemoteNames("origin", nil, nil).
-		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil)
-	remote, _ := GetRemote(context.Background(), s.Conn)
-
-	_, err := GetBranches(context.Background(), remote, s.Conn, shared.Merged, false)
-
-	assert.NotNil(t, err)
-}
-
 func Test_ReturnsErrorWhenGetBranchNamesFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
@@ -1178,7 +1094,6 @@ func Test_ReturnsErrorWhenGetMergedBranchNames(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
@@ -1196,50 +1111,15 @@ func Test_ReturnsErrorWhenGetLogFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, ErrCommand, nil).
-		GetConfig([]conn.ConfigStub{
-			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
-			{BranchName: "branch.main.gh-poi-protected", Filename: "empty"},
-			{BranchName: "branch.issue1.remote", Filename: "remote"},
-			{BranchName: "branch.issue1.gh-poi-locked", Filename: "empty"},
-			{BranchName: "branch.issue1.gh-poi-protected", Filename: "empty"},
-		}, nil, nil)
-	remote, _ := GetRemote(context.Background(), s.Conn)
-
-	_, err := GetBranches(context.Background(), remote, s.Conn, shared.Merged, false)
-
-	assert.NotNil(t, err)
-}
-
-func Test_ReturnsErrorWhenGetAssociatedRefNamesFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
-		GetRemoteNames("origin", nil, nil).
-		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
-		GetBranchNames("@main_issue1", nil, nil).
-		GetMergedBranchNames("@main", nil, nil).
-		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
-		GetLog([]conn.LogStub{
-			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, ErrCommand, nil).
 		GetConfig([]conn.ConfigStub{
 			{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
@@ -1260,20 +1140,15 @@ func Test_ReturnsErrorWhenGetPullRequestsFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", ErrCommand, nil).
 		GetUncommittedChanges("", nil, nil).
@@ -1297,20 +1172,15 @@ func Test_ReturnsErrorWhenGetUncommittedChangesFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", ErrCommand, nil).
@@ -1335,20 +1205,15 @@ func Test_ReturnsErrorWhenCheckoutBranchFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	s := conn.Setup(ctrl).
-		CheckRepos(nil, nil).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
 		GetRepoNames("origin", nil, nil).
 		GetBranchNames("main_@issue1", nil, nil).
 		GetMergedBranchNames("main", nil, nil).
 		GetRemoteHeadOid(nil, ErrCommand, nil).
-		GetLsRemoteHeadOid(nil, nil, nil).
+		GetUpstreamOid(nil, ErrCommand, nil).
 		GetLog([]conn.LogStub{
 			{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
-		}, nil, nil).
-		GetAssociatedRefNames([]conn.AssociatedBranchNamesStub{
-			{Oid: "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0", Filename: "issue1"},
-			{Oid: "6ebe3d30d23531af56bd23b5a098d3ccae2a534a", Filename: "main_issue1"},
 		}, nil, nil).
 		GetPullRequests("issue1Merged", nil, nil).
 		GetUncommittedChanges("", nil, nil).

--- a/conn/command.go
+++ b/conn/command.go
@@ -34,21 +34,6 @@ var (
 	scpLikeURLPattern = regexp.MustCompile("^([^@]+@)?([^:]+):(/?.+)$")
 )
 
-func (conn *Connection) CheckRepos(ctx context.Context, hostname string, repoNames []string) error {
-	for _, name := range repoNames {
-		args := []string{
-			"api",
-			"--hostname", hostname,
-			"repos/" + name,
-			"--silent",
-		}
-		if _, err := conn.run(ctx, "gh", args, None); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func GetRemoteNames(ctx context.Context, conn shared.Connection) ([]shared.Remote, error) {
 	output, err := conn.GetRemoteNames(ctx)
 	if err != nil {
@@ -153,6 +138,13 @@ func (conn *Connection) GetRemoteHeadOid(ctx context.Context, remoteName string,
 	return conn.run(ctx, "git", args, None)
 }
 
+func (conn *Connection) GetUpstreamOid(ctx context.Context, branchName string) (string, error) {
+	args := []string{
+		"rev-parse", fmt.Sprintf("%s@{upstream}", branchName),
+	}
+	return conn.run(ctx, "git", args, None)
+}
+
 func (conn *Connection) GetLsRemoteHeadOid(ctx context.Context, url string, branchName string) (string, error) {
 	args := []string{
 		"ls-remote", url, branchName,
@@ -162,15 +154,7 @@ func (conn *Connection) GetLsRemoteHeadOid(ctx context.Context, url string, bran
 
 func (conn *Connection) GetLog(ctx context.Context, branchName string) (string, error) {
 	args := []string{
-		"log", "--first-parent", "--max-count=30", "--format=%H", branchName, "--",
-	}
-	return conn.run(ctx, "git", args, None)
-}
-
-func (conn *Connection) GetAssociatedRefNames(ctx context.Context, oid string) (string, error) {
-	args := []string{
-		"branch", "--all", "--format=%(refname)",
-		"--contains", oid,
+		"log", "--max-count=1", "--format=%H", branchName, "--",
 	}
 	return conn.run(ctx, "git", args, None)
 }

--- a/conn/command_contract_test.go
+++ b/conn/command_contract_test.go
@@ -54,25 +54,6 @@ func TestContract_RepoBasic(t *testing.T) {
 		})
 	})
 
-	t.Run("GetAssociatedRefNames", func(t *testing.T) {
-
-		t.Run("issue1", func(t *testing.T) {
-			actual, _ := conn.GetAssociatedRefNames(context.Background(), "a97e9630426df5d34ca9ee77ae1159bdfd5ff8f0")
-			assert.Equal(t,
-				stub.ReadFile("git", "abranch", "issue1"),
-				actual,
-			)
-		})
-
-		t.Run("main_issue1", func(t *testing.T) {
-			actual, _ := conn.GetAssociatedRefNames(context.Background(), "6ebe3d30d23531af56bd23b5a098d3ccae2a534a")
-			assert.Equal(t,
-				stub.ReadFile("git", "abranch", "main_issue1"),
-				actual,
-			)
-		})
-	})
-
 	t.Run("GetUncommittedChanges", func(t *testing.T) {
 		actual, _ := conn.GetUncommittedChanges(context.Background())
 		assert.Equal(t, "A  README.md\n", actual)

--- a/conn/fixtures/git/abranch_forkMain.txt
+++ b/conn/fixtures/git/abranch_forkMain.txt
@@ -1,1 +1,0 @@
-refs/heads/fork/main

--- a/conn/fixtures/git/abranch_issue1.txt
+++ b/conn/fixtures/git/abranch_issue1.txt
@@ -1,1 +1,0 @@
-refs/heads/issue1

--- a/conn/fixtures/git/abranch_issue1_originMain.txt
+++ b/conn/fixtures/git/abranch_issue1_originMain.txt
@@ -1,2 +1,0 @@
-refs/heads/issue1
-refs/remotes/origin/main

--- a/conn/fixtures/git/abranch_main.txt
+++ b/conn/fixtures/git/abranch_main.txt
@@ -1,1 +1,0 @@
-refs/heads/main

--- a/conn/fixtures/git/abranch_main_forkMain.txt
+++ b/conn/fixtures/git/abranch_main_forkMain.txt
@@ -1,2 +1,0 @@
-refs/heads/fork/main
-refs/heads/main

--- a/conn/fixtures/git/abranch_main_issue1.txt
+++ b/conn/fixtures/git/abranch_main_issue1.txt
@@ -1,2 +1,0 @@
-refs/heads/issue1
-refs/heads/main

--- a/conn/stub.go
+++ b/conn/stub.go
@@ -28,14 +28,14 @@ type (
 		Filename   string
 	}
 
-	LsRemoteHeadStub struct {
+	UpstreamOidStub struct {
 		BranchName string
 		Filename   string
 	}
 
-	AssociatedBranchNamesStub struct {
-		Oid      string
-		Filename string
+	LsRemoteHeadStub struct {
+		BranchName string
+		Filename   string
 	}
 
 	LogStub struct {
@@ -66,18 +66,6 @@ func NewConf(times *Times) *Conf {
 	return &Conf{
 		times,
 	}
-}
-
-func (s *Stub) CheckRepos(err error, conf *Conf) *Stub {
-	s.T.Helper()
-	configure(
-		s.Conn.
-			EXPECT().
-			CheckRepos(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(err),
-		conf,
-	)
-	return s
 }
 
 func (s *Stub) GetRemoteNames(filename string, err error, conf *Conf) *Stub {
@@ -160,6 +148,28 @@ func (s *Stub) GetRemoteHeadOid(stubs []RemoteHeadStub, err error, conf *Conf) *
 	return s
 }
 
+func (s *Stub) GetUpstreamOid(stubs []UpstreamOidStub, err error, conf *Conf) *Stub {
+	s.T.Helper()
+	if stubs == nil {
+		configure(
+			s.Conn.EXPECT().
+				GetUpstreamOid(gomock.Any(), gomock.Any()).
+				Return("", err),
+			conf,
+		)
+	} else {
+		for _, stub := range stubs {
+			configure(
+				s.Conn.EXPECT().
+					GetUpstreamOid(gomock.Any(), stub.BranchName).
+					Return(s.ReadFile("git", "remoteHead", stub.Filename), err),
+				conf,
+			)
+		}
+	}
+	return s
+}
+
 func (s *Stub) GetLsRemoteHeadOid(stubs []LsRemoteHeadStub, err error, conf *Conf) *Stub {
 	s.T.Helper()
 	if stubs == nil {
@@ -178,19 +188,6 @@ func (s *Stub) GetLsRemoteHeadOid(stubs []LsRemoteHeadStub, err error, conf *Con
 				conf,
 			)
 		}
-	}
-	return s
-}
-
-func (s *Stub) GetAssociatedRefNames(stubs []AssociatedBranchNamesStub, err error, conf *Conf) *Stub {
-	s.T.Helper()
-	for _, stub := range stubs {
-		configure(
-			s.Conn.EXPECT().
-				GetAssociatedRefNames(gomock.Any(), stub.Oid).
-				Return(s.ReadFile("git", "abranch", stub.Filename), err),
-			conf,
-		)
 	}
 	return s
 }

--- a/mocks/poi_mock.go
+++ b/mocks/poi_mock.go
@@ -49,20 +49,6 @@ func (mr *MockConnectionMockRecorder) AddConfig(ctx, key, value interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddConfig", reflect.TypeOf((*MockConnection)(nil).AddConfig), ctx, key, value)
 }
 
-// CheckRepos mocks base method.
-func (m *MockConnection) CheckRepos(ctx context.Context, hostname string, repoNames []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckRepos", ctx, hostname, repoNames)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CheckRepos indicates an expected call of CheckRepos.
-func (mr *MockConnectionMockRecorder) CheckRepos(ctx, hostname, repoNames interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRepos", reflect.TypeOf((*MockConnection)(nil).CheckRepos), ctx, hostname, repoNames)
-}
-
 // CheckoutBranch mocks base method.
 func (m *MockConnection) CheckoutBranch(ctx context.Context, branchName string) (string, error) {
 	m.ctrl.T.Helper()
@@ -91,21 +77,6 @@ func (m *MockConnection) DeleteBranches(ctx context.Context, branchNames []strin
 func (mr *MockConnectionMockRecorder) DeleteBranches(ctx, branchNames interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBranches", reflect.TypeOf((*MockConnection)(nil).DeleteBranches), ctx, branchNames)
-}
-
-// GetAssociatedRefNames mocks base method.
-func (m *MockConnection) GetAssociatedRefNames(ctx context.Context, oid string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAssociatedRefNames", ctx, oid)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAssociatedRefNames indicates an expected call of GetAssociatedRefNames.
-func (mr *MockConnectionMockRecorder) GetAssociatedRefNames(ctx, oid interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssociatedRefNames", reflect.TypeOf((*MockConnection)(nil).GetAssociatedRefNames), ctx, oid)
 }
 
 // GetBranchNames mocks base method.
@@ -271,6 +242,21 @@ func (m *MockConnection) GetUncommittedChanges(ctx context.Context) (string, err
 func (mr *MockConnectionMockRecorder) GetUncommittedChanges(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUncommittedChanges", reflect.TypeOf((*MockConnection)(nil).GetUncommittedChanges), ctx)
+}
+
+// GetUpstreamOid mocks base method.
+func (m *MockConnection) GetUpstreamOid(ctx context.Context, branchName string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUpstreamOid", ctx, branchName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUpstreamOid indicates an expected call of GetUpstreamOid.
+func (mr *MockConnectionMockRecorder) GetUpstreamOid(ctx, branchName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpstreamOid", reflect.TypeOf((*MockConnection)(nil).GetUpstreamOid), ctx, branchName)
 }
 
 // GetWorktrees mocks base method.

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -4,16 +4,15 @@ package shared
 import "context"
 
 type Connection interface {
-	CheckRepos(ctx context.Context, hostname string, repoNames []string) error
 	GetRemoteNames(ctx context.Context) (string, error)
 	GetSshConfig(ctx context.Context, name string) (string, error)
 	GetRepoNames(ctx context.Context, hostname string, repoName string) (string, error)
 	GetBranchNames(ctx context.Context) (string, error)
 	GetMergedBranchNames(ctx context.Context, remoteName string, branchName string) (string, error)
 	GetRemoteHeadOid(ctx context.Context, remoteName string, branchName string) (string, error)
+	GetUpstreamOid(ctx context.Context, branchName string) (string, error)
 	GetLsRemoteHeadOid(ctx context.Context, url string, branchName string) (string, error)
 	GetLog(ctx context.Context, branchName string) (string, error)
-	GetAssociatedRefNames(ctx context.Context, oid string) (string, error)
 	GetPullRequests(ctx context.Context, hostname string, orgs string, repos string, queryHashes string) (string, error)
 	GetUncommittedChanges(ctx context.Context) (string, error)
 	GetConfig(ctx context.Context, key string) (string, error)


### PR DESCRIPTION
Two bottlenecks caused gh-poi to hang in repos with many branches:

1. Expensive per-commit ancestry walk (`trimBranch`, `extractBranchNames`, `GetAssociatedRefNames`) is now replaced with a single head commit lookup. We only need the head commit for PR matching. 

2. Removes the `GetLsRemoteHeadOid` network fallback in favor of `GetUpstreamOid`, and drops the redundant `CheckRepos`  validation since `GetRepoNames` already verifies repo existence.  Removing this saves 1-2 network calls per run (more with fork chains), directly improving startup latency.