### PR TITLE
add `--delete-remote` flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -766,6 +766,33 @@ func DeleteBranches(ctx context.Context, branches []shared.Branch, connection sh
 	return checkDeleted(branches, branchesAfter), nil
 }
 
+func DeleteRemoteBranches(ctx context.Context, branches []shared.Branch, remoteName string, connection shared.Connection) ([]string, error) {
+	var deleted []string
+	var errs []error
+	for _, branch := range branches {
+		if branch.State != shared.Deleted || branch.RemoteHeadOid == "" {
+			continue
+		}
+		_, err := connection.DeleteRemoteBranch(ctx, remoteName, branch.Name)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			deleted = append(deleted, branch.Name)
+		}
+	}
+	return deleted, errors.Join(errs...)
+}
+
+func GetDeletableRemoteBranches(branches []shared.Branch) []shared.Branch {
+	var results []shared.Branch
+	for _, branch := range branches {
+		if branch.State == shared.Deletable && branch.RemoteHeadOid != "" {
+			results = append(results, branch)
+		}
+	}
+	return results
+}
+
 func getBranchNames(branches []shared.Branch, state shared.BranchState) []string {
 	results := []string{}
 	for _, branch := range branches {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1412,3 +1412,176 @@ func Test_DoNotDeleteNotDeletableBranches(t *testing.T) {
 	assert.Equal(t, "main", actual[1].Name)
 	assert.Equal(t, shared.NotDeletable, actual[1].State)
 }
+
+func Test_DeleteRemoteBranches(t *testing.T) {
+	tests := []struct {
+		name        string
+		branches    []shared.Branch
+		setupMock   func(s *conn.Stub)
+		expected    []string
+		expectedErr error
+	}{
+		{
+			name:     "does nothing with empty branches",
+			branches: []shared.Branch{},
+			expected: nil,
+		},
+		{
+			name: "deletes remote branch for deleted branch with remote",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.Deleted},
+			},
+			expected: []string{"issue1"},
+		},
+		{
+			name: "does not delete remote branch without RemoteHeadOid",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "", State: shared.Deleted},
+			},
+			expected: nil,
+		},
+		{
+			name: "does not delete remote branch for deletable branch",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.Deletable},
+			},
+			expected: nil,
+		},
+		{
+			name: "does not delete remote branch for not-deletable branch",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.NotDeletable},
+			},
+			expected: nil,
+		},
+		{
+			name: "deletes multiple remote branches",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.Deleted},
+				{Name: "issue2", RemoteHeadOid: "def456", State: shared.Deleted},
+			},
+			expected: []string{"issue1", "issue2"},
+		},
+		{
+			name: "only deletes eligible branches from mixed set",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.Deleted},
+				{Name: "issue2", RemoteHeadOid: "", State: shared.Deleted},
+				{Name: "issue3", RemoteHeadOid: "ghi789", State: shared.NotDeletable},
+			},
+			expected: []string{"issue1"},
+		},
+		{
+			name: "continues deleting when one branch fails",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.Deleted},
+				{Name: "issue2", RemoteHeadOid: "def456", State: shared.Deleted},
+			},
+			setupMock: func(s *conn.Stub) {
+				first := s.Conn.EXPECT().
+					DeleteRemoteBranch(gomock.Any(), "origin", "issue1").
+					Return("", ErrCommand)
+				s.Conn.EXPECT().
+					DeleteRemoteBranch(gomock.Any(), "origin", "issue2").
+					Return("", nil).
+					After(first)
+			},
+			expected:    []string{"issue2"},
+			expectedErr: ErrCommand,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			s := conn.Setup(ctrl)
+			if tt.setupMock != nil {
+				tt.setupMock(s)
+			} else {
+				s.DeleteRemoteBranch(nil, conn.NewConf(&conn.Times{N: len(tt.expected)}))
+			}
+
+			deleted, err := DeleteRemoteBranches(context.Background(), tt.branches, "origin", s.Conn)
+
+			if tt.expectedErr != nil {
+				assert.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, deleted)
+		})
+	}
+}
+
+func Test_GetDeletableRemoteBranches(t *testing.T) {
+	tests := []struct {
+		name          string
+		branches      []shared.Branch
+		expectedNames []string
+	}{
+		{
+			name:          "returns nothing with empty branches",
+			branches:      []shared.Branch{},
+			expectedNames: nil,
+		},
+		{
+			name: "includes deletable branch with remote",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.Deletable},
+			},
+			expectedNames: []string{"issue1"},
+		},
+		{
+			name: "excludes deletable branch without remote",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "", State: shared.Deletable},
+			},
+			expectedNames: nil,
+		},
+		{
+			name: "excludes not-deletable branch with remote",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.NotDeletable},
+			},
+			expectedNames: nil,
+		},
+		{
+			name: "excludes deleted branch with remote",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.Deleted},
+			},
+			expectedNames: nil,
+		},
+		{
+			name: "returns multiple deletable branches with remote",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.Deletable},
+				{Name: "issue2", RemoteHeadOid: "def456", State: shared.Deletable},
+			},
+			expectedNames: []string{"issue1", "issue2"},
+		},
+		{
+			name: "filters only eligible branches from mixed set",
+			branches: []shared.Branch{
+				{Name: "issue1", RemoteHeadOid: "abc123", State: shared.Deletable},
+				{Name: "issue2", RemoteHeadOid: "", State: shared.Deletable},
+				{Name: "issue3", RemoteHeadOid: "ghi789", State: shared.NotDeletable},
+			},
+			expectedNames: []string{"issue1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := GetDeletableRemoteBranches(tt.branches)
+
+			var actualNames []string
+			for _, b := range actual {
+				actualNames = append(actualNames, b.Name)
+			}
+			assert.Equal(t, tt.expectedNames, actualNames)
+		})
+	}
+}

--- a/conn/command.go
+++ b/conn/command.go
@@ -257,6 +257,13 @@ func (conn *Connection) DeleteBranches(ctx context.Context, branchNames []string
 	return conn.run(ctx, "git", args, None)
 }
 
+func (conn *Connection) DeleteRemoteBranch(ctx context.Context, remoteName string, branchName string) (string, error) {
+	args := []string{
+		"push", remoteName, "--delete", branchName,
+	}
+	return conn.run(ctx, "git", args, None)
+}
+
 func (conn *Connection) PruneRemoteBranches(ctx context.Context, remoteName string) (string, error) {
 	args := []string{
 		"remote", "prune", remoteName,

--- a/conn/stub.go
+++ b/conn/stub.go
@@ -270,6 +270,18 @@ func (s *Stub) DeleteBranches(err error, conf *Conf) *Stub {
 	return s
 }
 
+func (s *Stub) DeleteRemoteBranch(err error, conf *Conf) *Stub {
+	s.T.Helper()
+	configure(
+		s.Conn.
+			EXPECT().
+			DeleteRemoteBranch(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return("", err),
+		conf,
+	)
+	return s
+}
+
 func (s *Stub) GetWorktrees(filename string, err error, conf *Conf) *Stub {
 	s.T.Helper()
 	configure(

--- a/main.go
+++ b/main.go
@@ -58,9 +58,11 @@ func (s StateFlag) toModel() shared.PullRequestState {
 func main() {
 	state := Merged
 	var dryRun bool
+	var deleteRemote bool
 	var debug bool
 	flag.Var(&state, "state", "Specify the PR state to delete by {closed|merged}")
 	flag.BoolVar(&dryRun, "dry-run", false, "Show branches to delete without actually deleting it")
+	flag.BoolVar(&deleteRemote, "delete-remote", false, "Delete branches on the remote (e.g. origin) in addition to local branches")
 	flag.BoolVar(&debug, "debug", false, "Enable debug logs")
 	flag.Usage = func() {
 		fmt.Fprintf(color.Output, "%s\n\n", "Delete the merged local branches.")
@@ -89,7 +91,7 @@ func main() {
 	args := flag.Args()
 
 	if len(args) == 0 {
-		runMain(state, dryRun, debug)
+		runMain(state, dryRun, deleteRemote, debug)
 	} else {
 		subcmd, args := args[0], args[1:]
 		switch subcmd {
@@ -127,7 +129,7 @@ func main() {
 	}
 }
 
-func runMain(state StateFlag, dryRun bool, debug bool) {
+func runMain(state StateFlag, dryRun bool, deleteRemote bool, debug bool) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
@@ -165,9 +167,14 @@ func runMain(state StateFlag, dryRun bool, debug bool) {
 	}
 
 	deletingMsg := " Deleting branches..."
+	deletingRemoteMsg := " Deleting remote branches..."
+	var deletedRemoteBranches []string
 
 	if dryRun {
 		fmt.Fprintf(color.Output, "%s%s\n", hiBlack("-"), deletingMsg)
+		if deleteRemote {
+			fmt.Fprintf(color.Output, "%s%s\n", hiBlack("-"), deletingRemoteMsg)
+		}
 	} else {
 		sp.Suffix = deletingMsg
 		if !debug {
@@ -185,6 +192,24 @@ func runMain(state StateFlag, dryRun bool, debug bool) {
 		} else {
 			fmt.Fprintf(color.Output, "%s%s\n", red("✕"), deletingMsg)
 			return
+		}
+
+		if deleteRemote {
+			sp.Suffix = deletingRemoteMsg
+			if !debug {
+				sp.Restart()
+			}
+
+			deletedRemoteBranches, err = cmd.DeleteRemoteBranches(ctx, branches, remote.Name, connection)
+
+			sp.Stop()
+
+			if err == nil {
+				fmt.Fprintf(color.Output, "%s%s\n", green("✔"), deletingRemoteMsg)
+			} else {
+				fmt.Fprintf(color.Output, "%s%s\n", red("✕"), deletingRemoteMsg)
+				fmt.Fprintln(os.Stderr, err)
+			}
 		}
 	}
 
@@ -207,6 +232,39 @@ func runMain(state StateFlag, dryRun bool, debug bool) {
 	fmt.Fprintf(color.Output, "%s\n", bold("Branches not deleted"))
 	printBranches(getBranches(branches, notDeletedStates))
 	fmt.Println()
+
+	if deleteRemote {
+		fmt.Fprintf(color.Output, "%s\n", bold("Deleted remote branches"))
+		if dryRun {
+			remoteBranches := cmd.GetDeletableRemoteBranches(branches)
+			printBranches(remoteBranches)
+		} else if len(deletedRemoteBranches) == 0 {
+			fmt.Fprintf(color.Output, "%s\n",
+				hiBlack("  There are no remote branches to delete"))
+		} else {
+			for _, name := range deletedRemoteBranches {
+				fmt.Fprintf(color.Output, "  %s\n", name)
+			}
+		}
+		fmt.Println()
+
+		if !dryRun {
+			var failedRemoteBranches []string
+			for _, branch := range branches {
+				if branch.State == shared.Deleted && branch.RemoteHeadOid != "" &&
+					!slices.Contains(deletedRemoteBranches, branch.Name) {
+					failedRemoteBranches = append(failedRemoteBranches, branch.Name)
+				}
+			}
+			if len(failedRemoteBranches) > 0 {
+				fmt.Fprintf(color.Output, "%s\n", bold("Remote branches not deleted"))
+				for _, name := range failedRemoteBranches {
+					fmt.Fprintf(color.Output, "  %s\n", name)
+				}
+				fmt.Println()
+			}
+		}
+	}
 }
 
 func runLock(branchNames []string, debug bool) {

--- a/mocks/poi_mock.go
+++ b/mocks/poi_mock.go
@@ -93,6 +93,21 @@ func (mr *MockConnectionMockRecorder) DeleteBranches(ctx, branchNames interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBranches", reflect.TypeOf((*MockConnection)(nil).DeleteBranches), ctx, branchNames)
 }
 
+// DeleteRemoteBranch mocks base method.
+func (m *MockConnection) DeleteRemoteBranch(ctx context.Context, remoteName, branchName string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRemoteBranch", ctx, remoteName, branchName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRemoteBranch indicates an expected call of DeleteRemoteBranch.
+func (mr *MockConnectionMockRecorder) DeleteRemoteBranch(ctx, remoteName, branchName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRemoteBranch", reflect.TypeOf((*MockConnection)(nil).DeleteRemoteBranch), ctx, remoteName, branchName)
+}
+
 // GetAssociatedRefNames mocks base method.
 func (m *MockConnection) GetAssociatedRefNames(ctx context.Context, oid string) (string, error) {
 	m.ctrl.T.Helper()

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -21,6 +21,7 @@ type Connection interface {
 	RemoveConfig(ctx context.Context, key string) (string, error)
 	CheckoutBranch(ctx context.Context, branchName string) (string, error)
 	DeleteBranches(ctx context.Context, branchNames []string) (string, error)
+	DeleteRemoteBranch(ctx context.Context, remoteName string, branchName string) (string, error)
 	GetWorktrees(ctx context.Context) (string, error)
 	RemoveWorktree(ctx context.Context, path string) (string, error)
 }


### PR DESCRIPTION
Closes #159 

## Summary
- Add `--delete-remote` flag that deletes branches on the remote (e.g. origin) after deleting local branches
- Supports `--dry-run` to preview which remote branches would be deleted
- Handles partial failures gracefully: continues deleting remaining branches and reports errors and failed branches

## Test plan
- [x] Unit tests for `DeleteRemoteBranches` (empty input, eligible/ineligible branches, partial failures)
- [x] Unit tests for `GetDeletableRemoteBranches` (filtering by state and remote presence)
- [ ] Manual test: `gh poi --delete-remote --dry-run` shows remote branches that would be deleted
- [ ] Manual test: `gh poi --delete-remote` deletes remote branches and displays results