### PR TITLE
Add branch head queries to detect squash-merged PRs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,14 +125,16 @@ func loadBranches(ctx context.Context, remote shared.Remote, defaultBranchName s
 	}
 
 	queryHashes := shared.GetQueryHashes(branches)
-	prChan := make(chan pullRequestResult, len(queryHashes))
+	queryHeads := shared.GetQueryHeads(branches)
+	queries := append(queryHashes, queryHeads...)
+	prChan := make(chan pullRequestResult, len(queries))
 	var wg sync.WaitGroup
 
-	for _, queryHash := range queryHashes {
+	for _, q := range queries {
 		wg.Add(1)
-		go func(hash string) {
+		go func(query string) {
 			defer wg.Done()
-			pullRequests, err := connection.GetPullRequests(ctx, remote.Hostname, orgs, repos, hash)
+			pullRequests, err := connection.GetPullRequests(ctx, remote.Hostname, orgs, repos, query)
 			if err != nil {
 				prChan <- pullRequestResult{err: err}
 				return
@@ -145,7 +147,7 @@ func loadBranches(ctx context.Context, remote shared.Remote, defaultBranchName s
 			}
 
 			prChan <- pullRequestResult{prs: pr}
-		}(queryHash)
+		}(q)
 	}
 
 	go func() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -263,6 +263,50 @@ func Test_GetBranchesWhenSquashAndMergedPR(t *testing.T) {
 
 /*
 // Before
+// main  : *---*(squash)
+//          \
+// topic :   * (PR squash-merged, hash search fails, head search finds PR)
+*/
+func Test_GetBranchesWhenSquashAndMergedPRInQuickScan(t *testing.T) {
+	t.Run("deletable", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		s := conn.Setup(ctrl).
+			GetRemoteNames("origin", nil, nil).
+			GetSshConfig("github.com", nil, nil).
+			GetRepoNames("origin", nil, nil).
+			GetBranchNames("@main_issue1", nil, nil).
+			GetMergedBranchNames("@main", nil, nil).
+			GetLog([]conn.LogStub{
+				{BranchName: "main", Filename: "main"}, {BranchName: "issue1", Filename: "issue1"},
+			}, nil, nil).
+			GetPullRequests("issue1Merged", nil, nil).
+			GetUncommittedChanges("", nil, nil).
+			GetWorktrees("none", nil, nil).
+			GetConfig([]conn.ConfigStub{
+				{BranchName: "branch.main.merge", Filename: "mergeMain"},
+				{BranchName: "branch.main.gh-poi-locked", Filename: "empty"},
+				{BranchName: "branch.main.gh-poi-protected", Filename: "empty"},
+				{BranchName: "branch.issue1.merge", Filename: "mergeIssue1"},
+				{BranchName: "branch.issue1.remote", Filename: "remote"},
+				{BranchName: "branch.issue1.gh-poi-locked", Filename: "empty"},
+				{BranchName: "branch.issue1.gh-poi-protected", Filename: "empty"},
+			}, nil, nil)
+		remote, _ := GetRemote(context.Background(), s.Conn)
+
+		actual, _ := GetBranches(context.Background(), remote, s.Conn, shared.Merged, shared.Quick, false)
+
+		assert.Equal(t, 2, len(actual))
+		assert.Equal(t, "issue1", actual[0].Name)
+		assert.Equal(t, shared.Deletable, actual[0].State)
+		assert.Equal(t, "main", actual[1].Name)
+		assert.Equal(t, shared.NotDeletable, actual[1].State)
+	})
+}
+
+/*
+// Before
 // upstream/main : *---*---*
 //                  \   ../
 // topic         :   *---* (PR merged)

--- a/shared/querygen.go
+++ b/shared/querygen.go
@@ -21,6 +21,36 @@ func GetQueryRepos(repoNames []string) string {
 	return strings.TrimSpace(repos.String())
 }
 
+func GetQueryHeads(branches []Branch) []string {
+	results := []string{}
+
+	var heads strings.Builder
+	for i, branch := range branches {
+		if len(branch.Commits) == 0 {
+			continue
+		}
+
+		separator := " "
+		if i == len(branches)-1 {
+			separator = ""
+		}
+		head := fmt.Sprintf("head:%s%s", branch.Name, separator)
+
+		// https://docs.github.com/en/rest/reference/search#limitations-on-query-length
+		if len(heads.String())+len(head) > 256 {
+			results = append(results, heads.String())
+			heads.Reset()
+		}
+
+		heads.WriteString(head)
+	}
+	if len(heads.String()) > 0 {
+		results = append(results, heads.String())
+	}
+
+	return results
+}
+
 func GetQueryHashes(branches []Branch) []string {
 	results := []string{}
 

--- a/shared/querygen_test.go
+++ b/shared/querygen_test.go
@@ -20,6 +20,18 @@ func Test_GetQueryRepos(t *testing.T) {
 	)
 }
 
+func Test_GetQueryHeads(t *testing.T) {
+	assert.Equal(t,
+		[]string{"head:issue1 head:issue2 head:issue3"},
+		GetQueryHeads([]Branch{
+			{Head: false, Name: "main", Commits: []string{}, PullRequests: []PullRequest{}, State: Unknown},
+			{Head: true, Name: "issue1", Commits: []string{"356a192b7913b04c54574d18c28d46e6395428ab"}, PullRequests: []PullRequest{}, State: Unknown},
+			{Head: false, Name: "issue2", Commits: []string{"08a2aaaadff191eb76974b9b3d8b71f202c0156e"}, PullRequests: []PullRequest{}, State: Unknown},
+			{Head: false, Name: "issue3", Commits: []string{"77de68daecd823babbb58edb1c8e14d7106e83bb"}, PullRequests: []PullRequest{}, State: Unknown},
+		}),
+	)
+}
+
 func Test_GetQueryHashesWithCommitOid(t *testing.T) {
 	assert.Equal(t,
 		[]string{


### PR DESCRIPTION
Fixes #170

Squash-merged branches weren't being detected because the commit hash search was failing. When a branch gets squash-merged, the original commits don't make it into the target branch, so that query returns nothing. Added a branch head query on top of the hash-based search, which catches PRs regardless of how they were merged.