### PR TITLE
Allow branch cleanup based on PRs from all remotes with `--scan deep`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -134,12 +134,40 @@ func GetBranches(ctx context.Context, remotes []shared.Remote, connection shared
 	Branch, error) {
 	var repoNames []string
 	var defaultBranchName string
-	if repos, err := connection.GetRepoNames(ctx, remotes[0].Hostname, remotes[0].RepoName); err == nil {
-		repoNames, defaultBranchName, err = getRepo(repos)
-		if err != nil {
-			return nil, err
+	var err error
+	if scan == shared.Quick {
+		if repos, e := connection.GetRepoNames(ctx, remotes[0].Hostname, remotes[0].ResolvedRepoName()); e == nil {
+			repoNames, defaultBranchName, err = getRepo(repos)
+		} else {
+			err = e
 		}
 	} else {
+		uniqueRepoNames := make(map[string]bool)
+		first := true
+		for _, remote := range remotes {
+			if repos, e := connection.GetRepoNames(ctx, remote.Hostname, remote.ResolvedRepoName()); e == nil {
+				names, defaultName, e := getRepo(repos)
+				if e != nil {
+					err = e
+					continue
+				}
+				for _, name := range names {
+					uniqueRepoNames[name] = true
+				}
+				if first {
+					defaultBranchName = defaultName
+				}
+			} else {
+				err = e
+				continue
+			}
+			first = false
+		}
+		for repoName := range uniqueRepoNames {
+			repoNames = append(repoNames, repoName)
+		}
+	}
+	if err != nil {
 		return nil, err
 	}
 
@@ -506,7 +534,7 @@ func findMatchedPullRequest(branchName string, prs []shared.PullRequest, prNumbe
 
 	prExists := func(pr shared.PullRequest) bool {
 		for _, result := range results {
-			if pr.Number == result.Number {
+			if pr.Url == result.Url && pr.Number == result.Number {
 				return true
 			}
 		}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -27,7 +27,9 @@ func Test_GetBranchesWhenMergedPR(t *testing.T) {
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("@main_issue1", nil, nil).
 				GetMergedBranchNames("@main_issue1", nil, nil).
 				GetLog([]conn.LogStub{
@@ -145,7 +147,9 @@ func Test_GetBranchesWhenSquashAndMergedPR(t *testing.T) {
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("@main_issue1", nil, nil).
 				GetMergedBranchNames("@main", nil, nil).
 				GetLog([]conn.LogStub{
@@ -221,7 +225,9 @@ func Test_GetBranchesWhenSquashAndMergedPRByUpstream(t *testing.T) {
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin_upstream", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin_upstream"},
+				}, nil, nil).
 				GetBranchNames("@main_issue1", nil, nil).
 				GetMergedBranchNames("@main", nil, nil).
 				GetLog([]conn.LogStub{
@@ -311,7 +317,9 @@ func Test_GetBranchesWhenMergedPRWithDefaultBranchAsHeadRef(t *testing.T) {
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("@main_issue1", nil, nil).
 				GetMergedBranchNames("@main", nil, nil).
 				GetLog([]conn.LogStub{
@@ -370,7 +378,9 @@ func Test_GetBranchesWhenSquashAndMergedToOriginAndMissingDefaultBranch(t *testi
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("@issue1", nil, nil).
 				GetMergedBranchNames("empty", nil, nil).
 				GetLog([]conn.LogStub{
@@ -427,7 +437,9 @@ func Test_GetBranchesWhenSquashAndMergedToUpstreamAndMissingDefaultBranch(t *tes
 			return s.
 				GetRemoteNames("origin_upstream", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("@issue1", nil, nil).
 				GetMergedBranchNames("empty", nil, nil).
 				GetLog([]conn.LogStub{
@@ -485,7 +497,9 @@ func Test_GetBranchesWhenSquashAndMergedPRWithChanges(t *testing.T) {
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("main_@issue1", nil, nil).
 				GetMergedBranchNames("main", nil, nil).
 				GetLog([]conn.LogStub{
@@ -565,7 +579,9 @@ func Test_GetBranchesWhenMergedPRWithNotFullyMerged(t *testing.T) {
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("@main_issue1", nil, nil).
 				GetMergedBranchNames("@main", nil, nil).
 				GetLog([]conn.LogStub{
@@ -626,7 +642,9 @@ func Test_GetBranchesWhenClosedPR(t *testing.T) {
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("@main_issue1", nil, nil).
 				GetMergedBranchNames("@main", nil, nil).
 				GetLog([]conn.LogStub{
@@ -701,7 +719,9 @@ func Test_GetBranchesWhenClosedAndMergedPRs(t *testing.T) {
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("@main_issue1", nil, nil).
 				GetMergedBranchNames("@main", nil, nil).
 				GetLog([]conn.LogStub{
@@ -776,7 +796,9 @@ func Test_GetBranchesWhenMergedPRIsLinkedWorktree(t *testing.T) {
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("@main_linkedIssue1", nil, nil).
 				GetMergedBranchNames("main_@linkedIssue1", nil, nil).
 				GetLog([]conn.LogStub{
@@ -895,7 +917,9 @@ func Test_GetBranchesWhenMergedPRIsMainWorktree(t *testing.T) {
 			return s.
 				GetRemoteNames("origin", nil, nil).
 				GetSshConfig("github.com", nil, nil).
-				GetRepoNames("origin", nil, nil).
+				GetRepoNames([]conn.RepoNamesStub{
+					{RepoName: "owner/repo", Filename: "origin"},
+				}, nil, nil).
 				GetBranchNames("@issue1_issue2", nil, nil).
 				GetMergedBranchNames("@main_issue1", nil, nil).
 				GetLog([]conn.LogStub{
@@ -966,7 +990,9 @@ func Test_BranchIsNotDeletableWhenFirstCommitOfTopicBranchIsAssociatedWithDefaul
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetLog([]conn.LogStub{
@@ -1005,7 +1031,9 @@ func Test_BranchesAndPRsAreNotAssociatedWhenManyLocalCommitsAreAhead(t *testing.
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetLog([]conn.LogStub{
@@ -1051,7 +1079,9 @@ func Test_NoCommitHistoryWhenFirstCommitOfTopicBranchIsAssociatedWithDefaultBran
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetLog([]conn.LogStub{
@@ -1094,7 +1124,9 @@ func Test_NoCommitHistoryWhenDetachedBranch(t *testing.T) {
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("main_@detached", nil, nil).
 		GetMergedBranchNames("main", nil, nil).
 		GetLog([]conn.LogStub{
@@ -1148,7 +1180,9 @@ func Test_DoesNotReturnErrorWhenGetSshConfigFails(t *testing.T) {
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", ErrCommand, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetLog([]conn.LogStub{
@@ -1187,7 +1221,9 @@ func Test_ReturnsErrorWhenGetRepoNamesFails(t *testing.T) {
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", ErrCommand, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, ErrCommand, nil).
 		GetConfig([]conn.ConfigStub{
 			{Key: "remote.origin.gh-resolved", Filename: "empty"},
 		}, nil, nil)
@@ -1205,7 +1241,9 @@ func Test_ReturnsErrorWhenGetBranchNamesFails(t *testing.T) {
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("@main_issue1", ErrCommand, nil).
 		GetConfig([]conn.ConfigStub{
 			{Key: "remote.origin.gh-resolved", Filename: "empty"},
@@ -1224,7 +1262,9 @@ func Test_ReturnsErrorWhenGetMergedBranchNamesFails(t *testing.T) {
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", ErrCommand, nil).
 		GetConfig([]conn.ConfigStub{
@@ -1244,7 +1284,9 @@ func Test_ReturnsErrorWhenGetLogFails(t *testing.T) {
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetLog([]conn.LogStub{
@@ -1272,7 +1314,9 @@ func Test_ReturnsErrorWhenGetAssociatedRefNamesFails(t *testing.T) {
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetLog([]conn.LogStub{
@@ -1304,7 +1348,9 @@ func Test_ReturnsErrorWhenGetPullRequestsFails(t *testing.T) {
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetLog([]conn.LogStub{
@@ -1341,7 +1387,9 @@ func Test_ReturnsErrorWhenGetUncommittedChangesFails(t *testing.T) {
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("@main_issue1", nil, nil).
 		GetMergedBranchNames("@main", nil, nil).
 		GetLog([]conn.LogStub{
@@ -1380,7 +1428,9 @@ func Test_ReturnsErrorWhenCheckoutBranchFails(t *testing.T) {
 	s := conn.Setup(ctrl).
 		GetRemoteNames("origin", nil, nil).
 		GetSshConfig("github.com", nil, nil).
-		GetRepoNames("origin", nil, nil).
+		GetRepoNames([]conn.RepoNamesStub{
+			{RepoName: "owner/repo", Filename: "origin"},
+		}, nil, nil).
 		GetBranchNames("main_@issue1", nil, nil).
 		GetMergedBranchNames("main", nil, nil).
 		GetLog([]conn.LogStub{

--- a/conn/stub.go
+++ b/conn/stub.go
@@ -23,6 +23,11 @@ type (
 		Times *Times
 	}
 
+	RepoNamesStub struct {
+		RepoName string
+		Filename string
+	}
+
 	RemoteHeadStub struct {
 		BranchName string
 		Filename   string
@@ -102,15 +107,17 @@ func (s *Stub) GetSshConfig(filename string, err error, conf *Conf) *Stub {
 	return s
 }
 
-func (s *Stub) GetRepoNames(filename string, err error, conf *Conf) *Stub {
+func (s *Stub) GetRepoNames(stubs []RepoNamesStub, err error, conf *Conf) *Stub {
 	s.T.Helper()
-	configure(
-		s.Conn.
-			EXPECT().
-			GetRepoNames(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(s.ReadFile("gh", "repo", filename), err),
-		conf,
-	)
+	for _, stub := range stubs {
+		configure(
+			s.Conn.
+				EXPECT().
+				GetRepoNames(gomock.Any(), gomock.Any(), stub.RepoName).
+				Return(s.ReadFile("gh", "repo", stub.Filename), err),
+			conf,
+		)
+	}
 	return s
 }
 

--- a/shared/remote.go
+++ b/shared/remote.go
@@ -6,3 +6,10 @@ type Remote struct {
 	RepoName   string
 	GhResolved string
 }
+
+func (r Remote) ResolvedRepoName() string {
+	if len(r.GhResolved) > 1 && r.GhResolved != "base" {
+		return r.GhResolved
+	}
+	return r.RepoName
+}

--- a/shared/remote_test.go
+++ b/shared/remote_test.go
@@ -1,0 +1,30 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ResolvedRepoName(t *testing.T) {
+	t.Run("returns repo from git config URL when gh-resolved is unset", func(t *testing.T) {
+		assert.Equal(t,
+			"owner/repo",
+			Remote{RepoName: "owner/repo"}.ResolvedRepoName(),
+		)
+	})
+
+	t.Run("returns repo from git config URL when gh-resolved base is set", func(t *testing.T) {
+		assert.Equal(t,
+			"owner/repo",
+			Remote{RepoName: "owner/repo", GhResolved: "base"}.ResolvedRepoName(),
+		)
+	})
+
+	t.Run("returns repo from gh-resolved when gh-resolved repo is set", func(t *testing.T) {
+		assert.Equal(t,
+			"upstream/repo",
+			Remote{RepoName: "owner/repo", GhResolved: "upstream/repo"}.ResolvedRepoName(),
+		)
+	})
+}


### PR DESCRIPTION
Related #156

```sh
seito@seitoPro poi-test % git remote -v
downstream      git@github.com:seachicken/poi-test.git (fetch)
downstream      git@github.com:seachicken/poi-test.git (push)
origin  git@github.com:inga-analysis/poi-test.git (fetch)
origin  git@github.com:inga-analysis/poi-test.git (push)
```

**--scan quick (default)**

Search for PRs targeting the origin and parent (a.k.a. upstream) remotes.

```sh
seito@seitoPro poi-test % gh poi --scan quick --dry-run                                                                                                                                                    [poi-test]
== DRY RUN ==
✔ Fetching pull requests...
- Deleting branches...

Deleted branches
  poi-test
    └─ #1  https://github.com/inga-analysis/poi-test/pull/1 seachicken

Branches not deleted
* main
```

**--scan deep**

Search PRs for all remotes (e.g., origin, upstream, midstream, downstream).

```sh
seito@seitoPro poi-test % gh poi --scan deep --dry-run
== DRY RUN ==
✔ Fetching pull requests...
- Deleting branches...

Deleted branches
  There are no branches in the current directory

Branches not deleted
  main
* poi-test
    ├─ #1  https://github.com/inga-analysis/poi-test/pull/1 seachicken
    └─ #1  https://github.com/seachicken/poi-test/pull/1 seachicken
```