### PR TITLE
Do not delete worktree with untracked files

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -403,15 +403,12 @@ func applyTrackedChanges(ctx context.Context, branches []shared.Branch, connecti
 			}
 		}
 
-		hasTrackedChanges := false
 		for _, change := range changes {
-			if !change.IsUntracked() {
+			if change.IsUntracked() {
+				branch.HasUntrackedFiles = true
+			} else {
 				branch.HasTrackedChanges = true
-				break
 			}
-		}
-		if hasTrackedChanges {
-			branch.HasTrackedChanges = true
 		}
 		results = append(results, branch)
 	}
@@ -582,7 +579,7 @@ func getDeleteStatus(branch shared.Branch, state shared.PullRequestState) shared
 	}
 
 	if branch.Worktree != nil {
-		if branch.Worktree.IsLocked || (branch.Worktree.IsMain && !branch.Head) || (!branch.Worktree.IsMain && branch.Head) {
+		if branch.Worktree.IsLocked || (branch.Worktree.IsMain && !branch.Head) || (!branch.Worktree.IsMain && branch.Head) || branch.HasUntrackedFiles {
 			return shared.NotDeletable
 		}
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -655,7 +655,7 @@ func Test_GetBranchesWhenSquashAndMergedPRWithChanges(t *testing.T) {
 			assert.Equal(t, shared.NotDeletable, actual[1].State)
 		})
 
-		t.Run("deletable with untracking uncommitted changes", func(t *testing.T) {
+		t.Run("deletable with untracked files", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			s := conn.Setup(ctrl).
@@ -974,6 +974,25 @@ func Test_GetBranchesWhenMergedPRIsLinkedWorktree(t *testing.T) {
 			s := conn.Setup(ctrl).
 				GetUncommittedChanges([]conn.UncommittedChangeStub{
 					{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_linkedIssue1", Output: " M README.md"},
+				}, nil, nil)
+			setupDefault(s)
+			remotes, _ := GetPreferredRemotes(context.Background(), s.Conn, scan)
+
+			actual, _ := GetBranches(context.Background(), remotes, s.Conn, shared.Merged, scan, false)
+
+			assert.Equal(t, 2, len(actual))
+			assert.Equal(t, "linkedIssue1", actual[0].Name)
+			assert.Equal(t, shared.NotDeletable, actual[0].State)
+			assert.Equal(t, "main", actual[1].Name)
+			assert.Equal(t, shared.NotDeletable, actual[1].State)
+		})
+
+		t.Run("not deletable with untracked files", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			s := conn.Setup(ctrl).
+				GetUncommittedChanges([]conn.UncommittedChangeStub{
+					{Path: "/home/runner/work/gh-poi/gh-poi/conn/fixtures/repo_worktree_linkedIssue1", Output: "?? new.txt"},
 				}, nil, nil)
 			setupDefault(s)
 			remotes, _ := GetPreferredRemotes(context.Background(), s.Conn, scan)

--- a/main.go
+++ b/main.go
@@ -296,6 +296,8 @@ func printBranches(branches []shared.Branch) {
 				reason = "main worktree"
 			} else if branch.Worktree != nil && !branch.Worktree.IsMain && branch.Head {
 				reason = "worktree here"
+			} else if branch.Worktree != nil && branch.HasUntrackedFiles {
+				reason = "untracked files"
 			} else if !branch.IsDefault && len(branch.PullRequests) > 0 && branch.HasTrackedChanges {
 				reason = "uncommitted changes"
 			}

--- a/shared/branch.go
+++ b/shared/branch.go
@@ -14,6 +14,7 @@ type (
 		IsMerged          bool
 		IsLocked          bool
 		HasTrackedChanges bool
+		HasUntrackedFiles bool
 		Commits           []string
 		PullRequests      []PullRequest
 		State             BranchState


### PR DESCRIPTION
Fixes #177

```sh
seito@seitoPro gomibako % gh poi --dry-run                                                                                                                                                              [test-branch]
== DRY RUN ==
✔ Fetching pull requests...
- Deleting branches...

Deleted branches
  There are no branches in the current directory

Branches not deleted
  gomibako-wk2 (worktree: /Users/seito/git/GitHub/gomibako-wk2) [untracked files]
    └─ #36  https://github.com/seachicken/gomibako/pull/36 seachicken
  main
```