### PR TITLE
Fix untracked file deletion

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -579,7 +579,7 @@ func getDeleteStatus(branch shared.Branch, state shared.PullRequestState) shared
 	}
 
 	if branch.Worktree != nil {
-		if branch.Worktree.IsLocked || (branch.Worktree.IsMain && !branch.Head) || (!branch.Worktree.IsMain && branch.Head) || branch.HasUntrackedFiles {
+		if branch.Worktree.IsLocked || (branch.Worktree.IsMain && !branch.Head) || (!branch.Worktree.IsMain && branch.Head) || (!branch.Worktree.IsMain && branch.HasUntrackedFiles) {
 			return shared.NotDeletable
 		}
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1108,6 +1108,27 @@ func Test_GetBranchesWhenMergedPRIsMainWorktree(t *testing.T) {
 			assert.Equal(t, "issue2", actual[1].Name)
 			assert.Equal(t, shared.NotDeletable, actual[1].State)
 		})
+
+		t.Run("deletable with untracked files", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			s := conn.Setup(ctrl).
+				GetUncommittedChanges([]conn.UncommittedChangeStub{
+					{Path: "", Output: "?? new.txt"},
+				}, nil, nil)
+			setupDefault(s)
+			remotes, _ := GetPreferredRemotes(context.Background(), s.Conn, scan)
+
+			actual, _ := GetBranches(context.Background(), remotes, s.Conn, shared.Merged, scan, false)
+
+			assert.Equal(t, 3, len(actual))
+			assert.Equal(t, "(HEAD detached at origin/main)", actual[0].Name)
+			assert.Equal(t, shared.NotDeletable, actual[0].State)
+			assert.Equal(t, "issue1", actual[1].Name)
+			assert.Equal(t, shared.Deletable, actual[1].State)
+			assert.Equal(t, "issue2", actual[2].Name)
+			assert.Equal(t, shared.NotDeletable, actual[2].State)
+		})
 	})
 }
 


### PR DESCRIPTION
If there are untracked files in the main worktree, deleting the branch will not result in an error per git's specifications, so we will modify it to allow cleanup.