### PR TITLE
Switch to latest detached branch

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -659,7 +659,11 @@ func switchToDefaultBranchIfDeleted(ctx context.Context, remotes []shared.Remote
 	} else {
 		newBranchName = remoteName + "/" + defaultBranchName
 		if !dryRun {
-			_, err := connection.CheckoutBranch(ctx, newBranchName, true)
+			_, err := connection.FetchBranch(ctx, remoteName, defaultBranchName)
+			if err != nil {
+				return nil, err
+			}
+			_, err = connection.CheckoutBranch(ctx, newBranchName, true)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -513,6 +513,7 @@ func Test_GetBranchesWhenSquashAndMergedToOriginAndMissingDefaultBranch(t *testi
 					{Key: "branch.issue1.gh-poi-locked", Filename: "empty"},
 					{Key: "branch.issue1.gh-poi-protected", Filename: "empty"},
 				}, nil, nil).
+				FetchBranch(nil, nil).
 				CheckoutBranch(nil, nil)
 		}
 
@@ -573,6 +574,7 @@ func Test_GetBranchesWhenSquashAndMergedToUpstreamAndMissingDefaultBranch(t *tes
 					{Key: "branch.issue1.gh-poi-locked", Filename: "empty"},
 					{Key: "branch.issue1.gh-poi-protected", Filename: "empty"},
 				}, nil, nil).
+				FetchBranch(nil, nil).
 				CheckoutBranch(nil, nil)
 		}
 
@@ -1071,6 +1073,7 @@ func Test_GetBranchesWhenMergedPRIsMainWorktree(t *testing.T) {
 					{Key: "branch.issue2.gh-poi-locked", Filename: "empty"},
 					{Key: "branch.issue2.gh-poi-protected", Filename: "empty"},
 				}, nil, nil).
+				FetchBranch(nil, nil).
 				CheckoutBranch(nil, nil)
 		}
 

--- a/conn/command.go
+++ b/conn/command.go
@@ -247,6 +247,13 @@ func (conn *Connection) RemoveConfig(ctx context.Context, key string) (string, e
 	return conn.run(ctx, "git", args, None)
 }
 
+func (conn *Connection) FetchBranch(ctx context.Context, remoteName string, branchName string) (string, error) {
+	args := []string{
+		"fetch", remoteName, branchName,
+	}
+	return conn.run(ctx, "git", args, None)
+}
+
 func (conn *Connection) CheckoutBranch(ctx context.Context, branchName string, detach bool) (string, error) {
 	args := []string{
 		"checkout", "--quiet", branchName,

--- a/conn/stub.go
+++ b/conn/stub.go
@@ -219,6 +219,18 @@ func (s *Stub) GetConfig(stubs []ConfigStub, err error, conf *Conf) *Stub {
 	return s
 }
 
+func (s *Stub) FetchBranch(err error, conf *Conf) *Stub {
+	s.T.Helper()
+	configure(
+		s.Conn.
+			EXPECT().
+			FetchBranch(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return("", err),
+		conf,
+	)
+	return s
+}
+
 func (s *Stub) CheckoutBranch(err error, conf *Conf) *Stub {
 	s.T.Helper()
 	configure(

--- a/mocks/poi_mock.go
+++ b/mocks/poi_mock.go
@@ -85,6 +85,21 @@ func (mr *MockConnectionMockRecorder) DeleteBranches(ctx, branchNames any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBranches", reflect.TypeOf((*MockConnection)(nil).DeleteBranches), ctx, branchNames)
 }
 
+// FetchBranch mocks base method.
+func (m *MockConnection) FetchBranch(ctx context.Context, remoteName, branchName string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchBranch", ctx, remoteName, branchName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchBranch indicates an expected call of FetchBranch.
+func (mr *MockConnectionMockRecorder) FetchBranch(ctx, remoteName, branchName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchBranch", reflect.TypeOf((*MockConnection)(nil).FetchBranch), ctx, remoteName, branchName)
+}
+
 // GetAssociatedRefNames mocks base method.
 func (m *MockConnection) GetAssociatedRefNames(ctx context.Context, oid string) (string, error) {
 	m.ctrl.T.Helper()

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -16,6 +16,7 @@ type Connection interface {
 	GetConfig(ctx context.Context, key string) (string, error)
 	AddConfig(ctx context.Context, key string, value string) (string, error)
 	RemoveConfig(ctx context.Context, key string) (string, error)
+	FetchBranch(ctx context.Context, remoteName string, branchName string) (string, error)
 	CheckoutBranch(ctx context.Context, branchName string, detach bool) (string, error)
 	DeleteBranches(ctx context.Context, branchNames []string) (string, error)
 	GetWorktrees(ctx context.Context) (string, error)


### PR DESCRIPTION
Since we don't track the local main branch, we need upstream/main to be up-to-date after cleanup for a smoother workflow. This PR adds a fetch step before checking out the detached branch.