### PR TITLE
Run worktree prune for cleanup

### DIFF
--- a/conn/command.go
+++ b/conn/command.go
@@ -336,6 +336,13 @@ func (conn *Connection) RemoveWorktree(ctx context.Context, path string) (string
 	return conn.run(ctx, "git", args, None)
 }
 
+func (conn *Connection) PruneWorktrees(ctx context.Context) (string, error) {
+	args := []string{
+		"worktree", "prune",
+	}
+	return conn.run(ctx, "git", args, None)
+}
+
 func (conn *Connection) run(ctx context.Context, name string, args []string, mask DebugMask) (string, error) {
 	cmdPath, err := safeexec.LookPath(name)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -209,6 +209,7 @@ func runMain(state StateFlag, scan ScanFlag, dryRun bool, debug bool) {
 		var deletingErr error
 		branches, deletingErr = cmd.DeleteBranches(ctx, branches, connection)
 		connection.PruneRemoteBranches(ctx, remotes[0].Name)
+		connection.PruneWorktrees(ctx)
 
 		sp.Stop()
 


### PR DESCRIPTION
Cleans up obsolete worktrees in the same way as remote branches.