### PR TITLE
Support deleting worktrees that include submodules

### DIFF
--- a/conn/command.go
+++ b/conn/command.go
@@ -331,7 +331,7 @@ func parseWorktrees(output string) []shared.Worktree {
 
 func (conn *Connection) RemoveWorktree(ctx context.Context, path string) (string, error) {
 	args := []string{
-		"worktree", "remove", path,
+		"worktree", "remove", "--force", path,
 	}
 	return conn.run(ctx, "git", args, None)
 }


### PR DESCRIPTION
https://github.com/seachicken/gh-poi/issues/185

`git worktree remove` cannot remove submodules.

```bash
$ git worktree remove /Users/seito/git/GitHub/poi-test-w
fatal: working trees containing submodules cannot be moved or removed
```

>Unclean worktrees or ones with submodules can be removed with --force. 

https://git-scm.com/docs/git-worktree#Documentation/git-worktree.txt-remove

In poi, branches are deleted with `--force` only after determining that they are safe to delete and have no changes. Worktrees should also be deleted with `--force`.